### PR TITLE
ci(release): finalize automation of post-release workflow

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -26,3 +26,23 @@ jobs:
         run: poetry publish --build --dry-run
       - name: Publish to PyPI
         run: poetry publish --build
+  sync-dev:
+    name: Sync main back to development
+    needs: publish
+    runs-on: ubuntu-latest
+    if: github.event.release.published == true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Merge main into development
+        run: |
+          git fetch origin
+          git checkout development
+          git merge origin/main --no-edit
+          git push origin development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,4 +1,5 @@
 ---
+# .github/workflows/release-please.yaml
 name: release-please
 on:
   push:
@@ -13,7 +14,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: python
           package-name: utils-repl

--- a/.make/git.mk
+++ b/.make/git.mk
@@ -29,13 +29,6 @@ start-release:
 	git checkout -b release/prepare-$(DATE)
 	git push -u origin release/prepare-$(DATE)
 
-# Merge main back into development after a release
-# Usage: make sync-dev
-sync-dev:
-	git checkout development
-	git pull origin development
-	git merge main
-	git push origin development
 
 # 📋 GitHub PR Commands
 


### PR DESCRIPTION
### Summary

This PR completes the transition to a fully automated post-release workflow by:

- Replacing the deprecated `google-github-actions/release-please-action` with the maintained `googleapis/release-please-action`
- Adding a `sync-dev` job to `publish-pypi.yaml` that automatically merges `main` into `development` after a successful GitHub Release
- Removing the now-redundant `make sync-dev` target and the "Post-Release Sync" section from CONTRIBUTING.md

### Benefits

- Eliminates manual steps for the release admin
- Reduces risk of drift between `main` and `development`
- Simplifies contributor documentation and onboarding

- **ci(release): switch to maintained release-please action and fix permissions**
- **ci(release): automate main → development sync after successful release**
- **chore(release): remove manual sync-dev target and contributor guidance**
