### PR TITLE
chore(dev): enforce Conventional Commits via commitizen and commit-msg hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
   - repo: https://github.com/google/yamlfmt
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: yamlfmt
         name: YAML Formatter (yamlfmt)
@@ -35,7 +35,7 @@ repos:
           - -formatter=eof_newline=true
           - -formatter=gitignore_path=".gitignore"
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.37.1
     hooks:
       - id: yamllint
         name: YAML Linter (yamllint)
@@ -50,12 +50,17 @@ repos:
           - "{extends: default, rules: { line-length: { max: 88, level: warning, allow-non-breakable-inline-mappings:
             true } } }"
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.6.2
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]
   # ============== GitHub Actions Workflows ======================
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.6
+    rev: v1.7.7
     hooks:
       - id: actionlint
         name: Lint GitHub Actions workflow files
@@ -79,7 +84,7 @@ repos:
         args: [-f, gcc, -x]  # output filename:linenum:colnum (clickable)
         # ============ Python ============================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.11.8
     hooks:
       - id: ruff
         types: [python]
@@ -109,7 +114,7 @@ repos:
         language: python
         types: [python]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         name: mypy
@@ -122,7 +127,7 @@ repos:
         minimum_pre_commit_version: 2.9.2
         # ===================== JavaScript =============================
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.17.0
+    rev: v9.26.0
     hooks:
       - id: eslint
         name: ESLint JavaScript Linter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ packages = [{ include = "utils_repl", from = "src" }]
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
 pytest-cov = "^6.1.1"
+commitizen = "^4.6.2"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
### Summary

This PR introduces commit message linting to enforce the Conventional Commits specification across all development activity.

### Changes

- Added `commitizen` to the Poetry development group for commit message validation
- Configured a `commit-msg` stage hook in `.pre-commit-config.yaml` to lint messages using `commitizen`
- Declared `[tool.commitizen]` configuration in `pyproject.toml` using the `cz_conventional_commits` adapter
- Upgraded several dev tool hooks to the latest compatible versions:
  - `yamlfmt`, `yamllint`, `codespell`, `actionlint`, `ruff`, `mypy`, and `eslint`

### Benefits

- Prevents invalid or non-conforming commit messages at the point of commit
- Aligns commit hygiene with release-please expectations
- Reduces the likelihood of malformed history, missed changelog entries, or CI inconsistencies

- Added commitizen to dev dependencies for commit message linting
- Configured pre-commit to run commitizen at the commit-msg stage
- Declared [tool.commitizen] in pyproject.toml using cz_conventional_commits format
- Upgraded versions of yamlfmt, yamllint, codespell, actionlint, ruff, mypy, and eslint to latest supported revisions

This ensures all commit messages conform to the Conventional Commits spec and blocks invalid messages at commit time.
