### PR TITLE
feat(ci): consolidate and harden ruleset workflows with contextual validation and modular design

### DIFF
--- a/.github/actions/github-rest-api/action.yml
+++ b/.github/actions/github-rest-api/action.yml
@@ -28,6 +28,9 @@ outputs:
   response:
     description: "The raw API response as a string"
     value: ${{ steps.request.outputs.response }}
+  raw_json:
+    description: "The raw JSON response with no wrapping"
+    value: ${{ steps.request.outputs.raw_json }}
 runs:
   using: "composite"
   steps:

--- a/.github/rulesets/branch-default.json
+++ b/.github/rulesets/branch-default.json
@@ -11,10 +11,7 @@
   },
   "rules": [
     { "type": "creation" },
-    {
-      "type": "update",
-      "parameters": { "update_allows_fetch_and_merge": false }
-    },
+    { "type": "update" },
     { "type": "deletion" },
     { "type": "required_linear_history" },
     { "type": "required_signatures" },

--- a/.github/rulesets/toy-ruleset.json
+++ b/.github/rulesets/toy-ruleset.json
@@ -2,6 +2,7 @@
   "name": "toy-ruleset",
   "target": "branch",
   "enforcement": "disabled",
+  "bypass_actors": [],
   "conditions": {
     "ref_name": {
       "include": ["~ALL"],

--- a/.github/workflows/core-upsert-ruleset.yaml
+++ b/.github/workflows/core-upsert-ruleset.yaml
@@ -1,0 +1,64 @@
+---
+name: Core Upsert Ruleset
+on:
+  workflow_call:
+    inputs:
+      json:
+        description: "The full ruleset JSON string"
+        required: true
+        type: string
+      ruleset_name:
+        description: "The name of the ruleset (used for lookup)"
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN:
+        required: true
+      CI_ADMIN:
+        required: true
+    outputs:
+      ruleset_id:
+        description: "The post-upsert ID of the ruleset"
+        value: ${{ jobs.upsert.outputs.ruleset_id }}
+jobs:
+  put-or-post:
+    name: Determine API method
+    uses: ./.github/workflows/fetch-ruleset-id.yaml
+    with:
+      ruleset_name: ${{ inputs.ruleset_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  upsert:
+    name: Upsert Ruleset
+    needs: put-or-post
+    runs-on: ubuntu-latest
+    outputs:
+      ruleset_id: ${{ steps.post-ruleset.outputs.result }}
+    steps:
+      - name: PUT an existing ruleset
+        id: method-put
+        if: ${{ needs.put-or-post.outputs.ruleset_id }}
+        run: |-
+          echo "METHOD=PUT" >> "$GITHUB_ENV"
+          echo "ENDPOINT=/repos/${GITHUB_REPOSITORY}/rulesets/${{ needs.put-or-post.outputs.ruleset_id }}" >> "$GITHUB_ENV"
+      - name: POST a new ruleset
+        id: method-post
+        if: ${{ ! needs.put-or-post.outputs.ruleset_id }}
+        run: |-
+          echo "METHOD=POST" >> "$GITHUB_ENV"
+          echo "ENDPOINT=/repos/${{ github.repository }}/rulesets" >> "$GITHUB_ENV"
+      - name: Sanity check
+        if: ${{ ! env.METHOD }}
+        run: |
+          echo "❌ METHOD not set"
+          exit 1
+      - uses: actions/checkout@v4
+      - name: Upsert Default Branch Ruleset
+        id: post-ruleset
+        uses: ./.github/actions/github-rest-api
+        with:
+          method: ${{ env.METHOD }}
+          endpoint: ${{ env.ENDPOINT }}
+          json_body: ${{ inputs.json }}
+          token: ${{ secrets.CI_ADMIN }}
+          extract: '.id'

--- a/.github/workflows/core-validate-ruleset.yaml
+++ b/.github/workflows/core-validate-ruleset.yaml
@@ -1,0 +1,51 @@
+---
+# .github/workflows/core-validate-ruleset.yaml
+name: Validate Ruleset Content
+on:
+  workflow_call:
+    inputs:
+      expected_json:
+        required: true
+        type: string
+      ruleset_id:
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN:
+        required: true
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch ruleset from GitHub API
+        id: fetch
+        uses: ./.github/actions/github-rest-api
+        with:
+          method: GET
+          endpoint: /repos/${{ github.repository }}/rulesets/${{ inputs.ruleset_id
+            }}
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Compare expected vs actual ruleset
+        run: |-
+          echo '${{ toJSON(fromJSON(inputs.expected_json)) }}' | jq --sort-keys . > expected.json
+          echo '${{ toJSON(fromJSON(steps.fetch.outputs.response)) }}' \
+            | jq 'del(
+                .id,
+                .node_id,
+                ._links,
+                .source,
+                .source_type,
+                .created_at,
+                .updated_at,
+                .current_user_can_bypass
+              )' | jq --sort-keys . > actual.json
+
+
+          echo "🧪 Comparing JSON:"
+          if ! diff -u expected.json actual.json; then
+            echo "❌ Mismatch between expected and actual ruleset content"
+            exit 1
+          fi
+
+          echo "✅ Ruleset content matches"

--- a/.github/workflows/core-validate-ruleset.yaml
+++ b/.github/workflows/core-validate-ruleset.yaml
@@ -13,8 +13,24 @@ on:
     secrets:
       GH_TOKEN:
         required: true
+      CI_ADMIN:
+        required: true
 jobs:
+  gate-token:
+    name: Check the caller token
+    runs-on: ubuntu-latest
+    outputs:
+      context: ${{ steps.detect.outputs.context }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect Token Context
+        id: detect
+        uses: ./.github/actions/gate-token
+        with:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN  }}
+          CI_ADMIN: ${{ secrets.CI_ADMIN }}
   validate:
+    needs: gate-token
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +41,13 @@ jobs:
           method: GET
           endpoint: /repos/${{ github.repository }}/rulesets/${{ inputs.ruleset_id
             }}
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Compare expected vs actual ruleset
-        run: |-
-          echo '${{ toJSON(fromJSON(inputs.expected_json)) }}' | jq --sort-keys . > expected.json
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN}}
+      - name: Load & sort expected
+        run: |
+          echo '${{ toJSON(fromJSON(inputs.expected_json)) }}' \
+            | jq --sort-keys . > expected.json
+      - name: Load & sanitize actual
+        run: |
           echo '${{ toJSON(fromJSON(steps.fetch.outputs.response)) }}' \
             | jq 'del(
                 .id,
@@ -39,13 +58,20 @@ jobs:
                 .created_at,
                 .updated_at,
                 .current_user_can_bypass
-              )' | jq --sort-keys . > actual.json
-
-
-          echo "🧪 Comparing JSON:"
-          if ! diff -u expected.json actual.json; then
-            echo "❌ Mismatch between expected and actual ruleset content"
-            exit 1
+              )' \
+            | jq --sort-keys . > actual.json
+      - name: Strip out `bypass_actors` under CI
+        if: ${{ needs.gate-token.outputs.context == 'github' }}
+        run: |
+          # only delete if it exists; under `act` it already does
+          if jq 'has("bypass_actors")' expected.json | grep -q true; then
+            jq 'del(.bypass_actors)' expected.json > tmp && mv tmp expected.json
           fi
-
+      - name: Compare expected vs actual
+        run: |-
+          echo "🧪 Comparing JSON:"
+          diff -u expected.json actual.json || {
+            echo "❌ Mismatch between expected and actual ruleset content";
+            exit 1;
+          }
           echo "✅ Ruleset content matches"

--- a/.github/workflows/ruleset-default-branch.yaml
+++ b/.github/workflows/ruleset-default-branch.yaml
@@ -8,23 +8,6 @@ on:
         required: true
         type: string
         default: "./.github/rulesets/branch-default.json"
-  workflow_call:
-    inputs:
-      json:
-        type: string
-        required: true
-      ruleset_name:
-        type: string
-        required: true
-      called_from_smoke_test:
-        type: boolean
-        required: false
-        default: false
-    secrets:
-      GH_TOKEN:
-        required: true
-      CI_ADMIN:
-        required: true
 jobs:
   gate-admin:
     name: Check if caller is admin
@@ -49,63 +32,34 @@ jobs:
     name: Load Ruleset JSON and Ruleset Name
     needs: gate-token
     outputs:
-      json: ${{ steps.load-prod.outputs.json || inputs.json }}
-      ruleset_name: ${{ steps.load-prod.outputs.ruleset_name || inputs.ruleset_name
-        }}
+      json: ${{ steps.load-prod.outputs.json }}
+      ruleset_name: ${{ steps.load-prod.outputs.ruleset_name }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Load production ruleset
         id: load-prod
-        if: ${{ !inputs.called_from_smoke_test }}
         uses: ./.github/actions/load-json
         with:
           path: ${{ inputs.ruleset_path }}
   local-token:
     name: smoke the production ruleset and callback with it
     needs: [gate-token, load-ruleset]
-    if: ${{ needs.gate-token.outputs.context == 'act' && !inputs.called_from_smoke_test
-      }}
+    if: ${{ needs.gate-token.outputs.context == 'act' }}
     uses: ./.github/workflows/smoke-ruleset-default-branch.yaml
     with:
       json: ${{ needs.load-ruleset.outputs.json }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
-  fetch-id:
-    name: Fetch Ruleset ID
+  core-upsert-ruleset:
+    name: Upsert Ruleset
     needs: [gate-token, load-ruleset]
-    uses: ./.github/workflows/fetch-ruleset-id.yaml
+    if: ${{ needs.gate-token.outputs.context == 'github' }}
+    uses: ./.github/workflows/core-upsert-ruleset.yaml
     with:
+      json: ${{ needs.load-ruleset.outputs.json }}
       ruleset_name: ${{ needs.load-ruleset.outputs.ruleset_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-  upsert-default-branch-ruleset:
-    runs-on: ubuntu-latest
-    name: Upsert Default Branch Ruleset
-    needs: [gate-token, load-ruleset, fetch-id]
-    if: ${{ needs.gate-token.outputs.context == 'github' || (needs.gate-token.outputs.context
-      == 'act' && inputs.called_from_smoke_test) }}
-    steps:
-      - name: PATCH an existing ruleset
-        id: method-patch
-        if: ${{ needs.fetch-id.outputs.ruleset_id }}
-        run: echo "METHOD=PATCH" >> "$GITHUB_ENV"
-      - name: POST a new ruleset
-        id: method-post
-        if: ${{ ! needs.fetch-id.outputs.ruleset_id }}
-        run: echo "METHOD=POST" >> "$GITHUB_ENV"
-      - name: Sanity check
-        if: ${{ ! env.METHOD }}
-        run: |
-          echo "❌ METHOD not set"
-          exit 1
-      - uses: actions/checkout@v4
-      - name: Upsert Default Branch Ruleset
-        id: post-ruleset
-        uses: ./.github/actions/github-rest-api
-        with:
-          method: ${{ env.METHOD }}
-          endpoint: /repos/${{ github.repository }}/rulesets
-          json_body: ${{ needs.load-ruleset.outputs.json }}
-          token: ${{ secrets.CI_ADMIN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}

--- a/.github/workflows/smoke-core.yaml
+++ b/.github/workflows/smoke-core.yaml
@@ -1,0 +1,50 @@
+---
+name: Smoke Test Core Logic
+on:
+  workflow_dispatch:
+jobs:
+  load-toy-json:
+    name: Load Toy Ruleset JSON
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.load.outputs.json }}
+      ruleset_name: ${{ steps.load.outputs.ruleset_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Load toy ruleset
+        id: load
+        uses: ./.github/actions/load-json
+        with:
+          path: .github/rulesets/toy-ruleset.json
+  core-upsert-ruleset:
+    name: Upsert Toy Ruleset
+    needs: load-toy-json
+    uses: ./.github/workflows/core-upsert-ruleset.yaml
+    with:
+      json: ${{ needs.load-toy-json.outputs.json }}
+      ruleset_name: ${{ needs.load-toy-json.outputs.ruleset_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  core-validate-ruleset:
+    needs: [load-toy-json, core-upsert-ruleset]
+    uses: ./.github/workflows/core-validate-ruleset.yaml
+    with:
+      expected_json: ${{ toJSON(fromJSON(needs.load-toy-json.outputs.json)) }}
+      ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  cleanup:
+    name: Cleanup Toy Ruleset
+    needs: [core-upsert-ruleset, core-validate-ruleset]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete toy ruleset
+        uses: ./.github/actions/github-rest-api
+        with:
+          method: DELETE
+          endpoint: /repos/${{ github.repository }}/rulesets/${{ needs.core-upsert-ruleset.outputs.ruleset_id
+            }}
+          token: ${{ secrets.CI_ADMIN }}

--- a/.github/workflows/smoke-core.yaml
+++ b/.github/workflows/smoke-core.yaml
@@ -34,6 +34,7 @@ jobs:
       ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
   cleanup:
     name: Cleanup Toy Ruleset
     needs: [core-upsert-ruleset, core-validate-ruleset]

--- a/.github/workflows/smoke-ruleset-default-branch.yaml
+++ b/.github/workflows/smoke-ruleset-default-branch.yaml
@@ -40,52 +40,27 @@ jobs:
         run: |
           ruleset_name="$(echo '${{ steps.inject.outputs.smoked_json }}' | jq -r '.name')"
           echo "ruleset_name=$ruleset_name" >> "$GITHUB_OUTPUT"
-  post-smoked-ruleset:
-    name: post the smoked ruleset
+  core-upsert-ruleset:
+    name: Post Smoked Ruleset
     needs: prepare-smoked-ruleset
-    uses: ./.github/workflows/ruleset-default-branch.yaml
+    uses: ./.github/workflows/core-upsert-ruleset.yaml
     with:
       json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
       ruleset_name: ${{ needs.prepare-smoked-ruleset.outputs.smoked_ruleset_name }}
-      called_from_smoke_test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
-  find-smoked-ruleset-id:
-    name: assert that the ruleset was created
-    needs: [prepare-smoked-ruleset, post-smoked-ruleset]
-    uses: ./.github/workflows/fetch-ruleset-id.yaml
+  core-validate-ruleset:
+    needs: [prepare-smoked-ruleset, core-upsert-ruleset]
+    uses: ./.github/workflows/core-validate-ruleset.yaml
     with:
-      ruleset_name: ${{ needs.prepare-smoked-ruleset.outputs.smoked_ruleset_name }}
+      expected_json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
+      ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-  validate-smoke-ruleset:
-    runs-on: ubuntu-latest
-    needs: [prepare-smoked-ruleset, post-smoked-ruleset, find-smoked-ruleset-id]
-    steps:
-      - name: Fetch the smoke ruleset JSON
-        id: fetch
-        uses: ./.github/actions/github-rest-api
-        with:
-          method: GET
-          endpoint: /repos/${{ github.repository }}/rulesets/${{ needs.find-smoked-ruleset-id.outputs.ruleset_id
-            }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Compare expected vs. actual
-        run: |
-          echo '${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}' \
-            | jq --sort-keys . > expected.json
-          echo '${{ steps.fetch.outputs.response }}' \
-            | jq --sort-keys . > actual.json
-
-          if ! diff -u expected.json actual.json; then
-            echo "❌ Mismatch between input and fetched ruleset"
-            exit 1
-          fi
-          echo "✅ Ruleset content matches"
   cleanup-smoked-ruleset:
-    needs: [find-smoked-ruleset-id, validate-smoke-ruleset]  # ← ensures this job waits for validation to finish
-    if: always()  # ← “always” makes it run even if validate‐smoke‐ruleset failed
+    needs: [core-upsert-ruleset, core-validate-ruleset]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -93,6 +68,6 @@ jobs:
         uses: ./.github/actions/github-rest-api
         with:
           method: DELETE
-          endpoint: /repos/${{ github.repository }}/rulesets/${{ needs.find-smoked-ruleset-id.outputs.ruleset_id
+          endpoint: /repos/${{ github.repository }}/rulesets/${{ needs.core-upsert-ruleset.outputs.ruleset_id
             }}
           token: ${{ secrets.CI_ADMIN }}

--- a/.github/workflows/smoke-ruleset-default-branch.yaml
+++ b/.github/workflows/smoke-ruleset-default-branch.yaml
@@ -3,10 +3,11 @@ name: Smoke Test Default Branch Ruleset Workflow
 on:
   workflow_dispatch:
     inputs:
-      json:
-        description: "Default Branch Ruleset JSON body."
+      ruleset_path:
+        description: "the path to the ruleset json"
         required: true
         type: string
+        default: "./.github/rulesets/branch-default.json"
   workflow_call:
     inputs:
       json:
@@ -19,8 +20,23 @@ on:
       CI_ADMIN:
         required: true
 jobs:
+  load-json:
+    name: Load Ruleset JSON
+    outputs:
+      json: ${{ inputs.JSON || steps.load-prod.outputs.json }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ ! inputs.json }}
+        uses: actions/checkout@v4
+      - name: Load production ruleset
+        if: ${{ ! inputs.json }}
+        id: load-prod
+        uses: ./.github/actions/load-json
+        with:
+          path: ${{ inputs.ruleset_path }}
   prepare-smoked-ruleset:
     name: Modify the ruleset to prevent collisions
+    needs: load-json
     runs-on: ubuntu-latest
     outputs:
       smoked_json: ${{ steps.inject.outputs.smoked_json }}
@@ -30,7 +46,7 @@ jobs:
         id: inject
         run: |
           {
-          modified_json="$(echo '${{ inputs.json }}' | jq '.name |= "smoke \(. + "")"')"
+          modified_json="$(echo '${{ needs.load-json.outputs.json }}' | jq '.name |= "smoke \(. + "")"')"
           echo "smoked_json<<EOF"
           echo "$modified_json"
           echo "EOF"

--- a/.github/workflows/smoke-ruleset-default-branch.yaml
+++ b/.github/workflows/smoke-ruleset-default-branch.yaml
@@ -74,6 +74,7 @@ jobs:
       ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
   cleanup-smoked-ruleset:
     needs: [core-upsert-ruleset, core-validate-ruleset]
     if: always()


### PR DESCRIPTION
### Summary

This PR introduces robust enhancements to the GitHub Actions workflows responsible for managing and validating branch protection rulesets. The changes focus on eliminating redundancy, improving maintainability, and ensuring reliable local testing with `act` by normalizing behavior based on runtime context.

### Changes

#### 🧩 Modular Reuse and Simplification
- **Refactored `ruleset-default-branch.yaml`**:
  - Removed legacy `workflow_call` and inline upsert logic.
  - Delegated upsert and validation logic to new reusable workflows:
    - `core-upsert-ruleset.yaml`
    - `core-validate-ruleset.yaml`

- **Introduced `smoke-core.yaml`**:
  - Central smoke testing workflow.
  - Loads toy ruleset, calls core upsert and validate jobs, ensures cleanup.

#### 🧪 Local Testing Support
- **Enhanced `smoke-ruleset-default-branch.yaml`**:
  - Replaced `json` input with `ruleset_path` for `workflow_dispatch` support.
  - Added `load-json` job to support both file and direct input.
  - Simplified local invocation (`act`) by eliminating the need to embed raw JSON in input flags.

#### 🔐 Context-Aware Validation
- **Updated `core-validate-ruleset.yaml`**:
  - Added `gate-token` job to determine caller environment (`act` vs GitHub CI).
  - Conditionally strips `bypass_actors` from `expected.json` only under GitHub CI to avoid false failures.
  - Ensured deterministic diff behavior via pre-sorted `jq` pipelines.

#### 🔧 Supporting Improvements
- **`.github/actions/github-rest-api`**:
  - Exposed `raw_json` as an additional output for downstream parsing.

- **Test Ruleset JSON Files**:
  - Removed unsupported field `update_allows_fetch_and_merge`.
  - Explicitly added `bypass_actors: []` to toy ruleset for test accuracy.

### Benefits

- Enables seamless CI/CD validation across both GitHub-hosted runners and `act`-based local testing.
- Promotes reuse and clarity through core workflow delegation.
- Prevents validation drift caused by context-sensitive API response fields.
- Simplifies future maintenance by reducing coupling between smoke tests and internal logic.

This PR closes a key architectural loop by making validation resilient to context, self-contained, and fully portable across environments.

- **feat(workflow): add reusable core-upsert-ruleset.yaml for PUT/POST ruleset upserts**
- **feat(workflow): add core-validate-ruleset.yaml to verify ruleset content matches expected JSON**
- **feat(smoke): add smoke-core.yaml and refactor smoke-ruleset-default-branch.yaml to use core logic**
- **feat(github-rest-api): expose raw_json as an additional output**
- **fix(rulesets): remove fetch-and-merge parameter from update rule and add bypass_actors to toy ruleset**
- **refactor(ruleset-default-branch): delegate upsert logic to core workflow and remove smoke test branching**
- **feat(smoke-ruleset): support loading JSON from file in workflow_dispatch**
- **feat(ci): enhance ruleset-validation workflow and propagate CI_ADMIN**
