### PR TITLE
chore(ruleset): allow repository admins to bypass development branch ruleset

### DIFF
--- a/.github/rulesets/branch-development.json
+++ b/.github/rulesets/branch-development.json
@@ -2,7 +2,13 @@
   "name": "Development Branch Ruleset",
   "target": "branch",
   "enforcement": "active",
-  "bypass_actors": [],
+    "bypass_actors": [
+      {
+        "actor_type": "RepositoryRole",
+        "actor_id": 5,
+        "bypass_mode": "pull_request"
+      }
+    ],
   "conditions": {
     "ref_name": {
       "include": ["refs/heads/development"],


### PR DESCRIPTION
### Summary
Enable repository administrators to bypass the “update” and “non_fast_forward” protections on the development branch by adding a `bypass_actors` entry to the branch‐development ruleset.

### Changes
- Updated `.github/rulesets/branch-development.json`:
  - Added a `"bypass_actors"` array containing:
    ```json
    {
      "actor_type": "RepositoryRole",
      "actor_id": 5,
      "bypass_mode": "pull_request"
    }
    ```
  - Left existing `enforcement`, `conditions`, and rule definitions untouched.

### Benefits
- Allows admins to merge release and emergency PRs without disabling or removing branch protection rules.
- Preserves strict protections for non-admin contributors while granting necessary merge rights to administrators.
