### PR TITLE
chore: remove smoke-test spam and reapply bypass-actors

### DIFF
--- a/.github/rulesets/branch-development.json
+++ b/.github/rulesets/branch-development.json
@@ -2,7 +2,13 @@
   "name": "Development Branch Ruleset",
   "target": "branch",
   "enforcement": "active",
-  "bypass_actors": [],
+    "bypass_actors": [
+      {
+        "actor_type": "RepositoryRole",
+        "actor_id": 5,
+        "bypass_mode": "pull_request"
+      }
+    ],
   "conditions": {
     "ref_name": {
       "include": ["refs/heads/development"],


### PR DESCRIPTION
This PR drops all temporary smoke-test merges from development and reapplies only the two intended ruleset commits.