### PR TITLE
feat: add upsert-ruleset composite action and reusable reset workflow

### DIFF
--- a/.github/actions/github-rest-api/action.yml
+++ b/.github/actions/github-rest-api/action.yml
@@ -7,20 +7,38 @@ inputs:
   endpoint:
     description: "API endpoint path (e.g. /repos/owner/repo/rulesets)"
     required: true
+    type: string
   method:
     description: "HTTP method (GET, POST, PUT, DELETE)"
     required: false
-    default: "PUT"
+    type: string
   json_body:
     description: "JSON string for the request body"
     required: false
     default: "{}"
+    type: string
   token:
     description: "GitHub token used for authentication"
     required: true
+    type: string
   extract:
     description: "Optional jq expression to extract a value from the response"
     required: false
+    type: string
+  expected:
+    description: "Optional expected value to poll for"
+    required: false
+    type: string
+  retries:
+    description: "Number of retry attempts (if expected is set)"
+    required: false
+    default: 10
+    type: number
+  delay:
+    description: "Delay in seconds between retries"
+    required: false
+    default: 3
+    type: number
 outputs:
   result:
     description: "The extracted value, if extract was used"
@@ -44,32 +62,55 @@ runs:
           exit 1
         fi
 
-        HTTP_RESPONSE=$(mktemp)
-        HTTP_STATUS=$(curl -s -w "%{http_code}" -o "$HTTP_RESPONSE" \
-          --request "${{ inputs.method }}" \
-          --url "https://api.github.com${{ inputs.endpoint }}" \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          -H "Authorization: Bearer $TOKEN" \
-          -H "Content-Type: application/json" \
-          -d '${{ inputs.json_body }}')
+        for attempt in $(seq 1 "${{ inputs.retries }}"); do
+          echo "🌐 Request #$attempt: ${{ inputs.method }} https://api.github.com${{ inputs.endpoint }}"
 
-        # Show raw output for visibility
-        cat "$HTTP_RESPONSE" > response.json
+          HTTP_RESPONSE=$(mktemp)
+          HTTP_STATUS=$(curl -s -w "%{http_code}" -o "$HTTP_RESPONSE" \
+            --request "${{ inputs.method }}" \
+            --url "https://api.github.com${{ inputs.endpoint }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '${{ inputs.json_body }}')
 
-        # Always export the response as an output
+          cat "$HTTP_RESPONSE" > response.json
+
+          if [[ "$HTTP_STATUS" -ge 400 ]]; then
+            echo "❌ Request failed with status $HTTP_STATUS"
+            echo "🔎 Response:"
+            cat response.json
+            exit 1
+          fi
+
+          if [[ -n "${{ inputs.expected }}" ]]; then
+            VALUE=$(jq -r "${{ inputs.extract }}" response.json || echo "")
+            echo "🔍 Extracted value: $VALUE"
+
+            if [[ "$VALUE" == "${{ inputs.expected }}" ]]; then
+              echo "✅ Success: match found."
+              break
+            fi
+
+            if [[ "$attempt" -lt "${{ inputs.retries }}" ]]; then
+              echo "⏳ Waiting ${{ inputs.delay }} seconds before retry..."
+              sleep "${{ inputs.delay }}"
+            else
+              echo "❌ Failed: expected value '${{ inputs.expected }}' not found after ${{ inputs.retries }} attempts."
+              exit 1
+            fi
+          else
+            break
+          fi
+
+        done
+
         echo 'response<<EOF' >> "$GITHUB_OUTPUT"
         cat response.json >> "$GITHUB_OUTPUT"
         echo 'EOF' >> "$GITHUB_OUTPUT"
-
-        # Check status
-        if [[ "$HTTP_STATUS" -ge 400 ]]; then
-          echo "❌ Request failed with status $HTTP_STATUS"
-          echo "🔎 Response:"
-          cat response.json
-          exit 1
-        fi
     - id: extract
+      name: Extract result from response
       if: ${{ inputs.extract != '' }}
       shell: bash
       run: |-

--- a/.github/actions/upsert-ruleset/action.yml
+++ b/.github/actions/upsert-ruleset/action.yml
@@ -1,0 +1,57 @@
+---
+# .github/actions/upsert-ruleset/action.yml
+name: "upsert-ruleset"
+description: "Upsert a branch protection ruleset using GitHub REST API"
+inputs:
+  json:
+    description: "The full ruleset JSON string"
+    required: true
+  ruleset_name:
+    description: "The name of the ruleset (used for lookup)"
+    required: true
+  gh_token:
+    description: "Token for lookup"
+    required: true
+  ci_admin:
+    description: "Admin token for upserting"
+    required: true
+  repo:
+    description: "Target repo for ruleset operations"
+    required: false
+    default: ${{ github.repository }}
+outputs:
+  ruleset_id:
+    description: "The resulting ruleset ID"
+    value: ${{ steps.post.outputs.result }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Lookup ruleset ID
+      id: lookup
+      uses: ./.github/actions/github-rest-api
+      with:
+        method: GET
+        endpoint: /repos/${{ inputs.repo }}/rulesets
+        token: ${{ inputs.gh_token }}
+        extract: '.[] | select(.name == \"${{ inputs.ruleset_name }}\") | .id'
+    - name: Determine method
+      id: method
+      shell: bash
+      run: |
+        if [[ -n "${{ steps.lookup.outputs.result }}" ]]; then
+          echo "METHOD=PUT" >> "$GITHUB_ENV"
+          echo "ENDPOINT=/repos/${{ inputs.repo }}/rulesets/${{ steps.lookup.outputs.result }}" >> "$GITHUB_ENV"
+        else
+          echo "METHOD=POST" >> "$GITHUB_ENV"
+          echo "ENDPOINT=/repos/${{ inputs.repo }}/rulesets" >> "$GITHUB_ENV"
+        fi
+    - name: Upsert Ruleset
+      id: post
+      uses: ./.github/actions/github-rest-api
+      with:
+        method: ${{ env.METHOD }}
+        endpoint: ${{ env.ENDPOINT }}
+        json_body: ${{ inputs.json }}
+        token: ${{ inputs.ci_admin }}
+        extract: '.id'

--- a/.github/workflows/core-reset-smoke-repo.yaml
+++ b/.github/workflows/core-reset-smoke-repo.yaml
@@ -1,0 +1,82 @@
+# .github/workflows/core-reset-smoke-repo.yaml
+---
+name: Core Reset Smoke Repo
+on:
+  workflow_call:
+    inputs:
+      src_repo:
+        description: "Source repository to mirror (e.g. owner/repo)"
+        required: true
+        type: string
+      dst_repo:
+        description: "Destination smoke repository (e.g. owner/smoke-repo)"
+        required: true
+        type: string
+    secrets:
+      GH_TOKEN:
+        required: true
+      CI_ADMIN:
+        required: true
+jobs:
+  reset:
+    name: Reset smoke repo to source state
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror clone source repo
+        run: |
+          git clone --mirror https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ inputs.src_repo }} /tmp/mirror.git
+      - name: Push mirror to destination
+        working-directory: /tmp/mirror.git
+        run: |
+          # Remove hidden refs
+          git for-each-ref --format='%(refname)' refs/pull | xargs -n 1 git update-ref -d
+
+          git remote set-url origin https://x-access-token:${{ secrets.CI_ADMIN }}@github.com/${{ inputs.dst_repo }}
+          git push --mirror
+  apply-rulesets:
+    name: Apply Branch Protection Rulesets
+    runs-on: ubuntu-latest
+    needs: reset
+    strategy:
+      matrix:
+        ruleset:
+          - path: ./smoke-repo/.github/rulesets/branch-default.json
+          - path: ./smoke-repo/.github/rulesets/branch-release.json
+          - path: ./smoke-repo/.github/rulesets/branch-development.json
+          - path: ./smoke-repo/.github/rulesets/branch-feature.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.dst_repo }}
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          path: smoke-repo
+      - name: "Load JSON: ruleset = ${{ matrix.ruleset.path }}"
+        id: load-json
+        uses: ./smoke-repo/.github/actions/load-json
+        with:
+          path: ${{ matrix.ruleset.path }}
+      - name: "Core Upsert Ruleset = ${{ matrix.ruleset.path }}"
+        id: upsert
+        uses: ./smoke-repo/.github/actions/upsert-ruleset
+        with:
+          json: ${{ steps.load-json.outputs.json }}
+          ruleset_name: ${{ steps.load-json.outputs.ruleset_name }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          ci_admin: ${{ secrets.CI_ADMIN }}
+      - name: "Validate Ruleset = ${{ matrix.ruleset.path }}"
+        uses: ./smoke-repo/.github/workflows/core-validate-ruleset.yaml
+        with:
+          expected_json: ${{ steps.load-json.outputs.json }}
+          ruleset_id: ${{ steps.upsert.outputs.ruleset_id }}
+      - name: "Query GitHub REST API for ruleset ${{ matrix.ruleset.path }}"
+        id: query
+        uses: ./smoke-repo/.github/actions/github-rest-api
+        with:
+          endpoint: /repos/robert-portelli/smoke-utils-repl/rulesets/${{ steps.load-json.outputs.ruleset_name
+            }}
+          method: GET
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extract: '.enforcement'
+          expected: 'active'
+          retries: 3
+          delay: 5

--- a/.github/workflows/smoke-core-reset-smoke-repo.yaml
+++ b/.github/workflows/smoke-core-reset-smoke-repo.yaml
@@ -1,0 +1,112 @@
+---
+# .github/workflows/smoke-core-reset-smoke-repo.yaml
+name: Smoke Test Reset Smoke Repo
+on:
+  workflow_dispatch:
+    inputs:
+      src_repo:
+        required: true
+        type: string
+        default: robert-portelli/utils-repl
+      dst_repo:
+        required: true
+        type: string
+        default: robert-portelli/smoke-utils-repl
+jobs:
+  dst-reset:
+    name: Start the smoke repo from a known state
+    uses: ./.github/workflows/core-reset-smoke-repo.yaml
+    with:
+      src_repo: ${{ inputs.SRC_REPO }}
+      dst_repo: ${{ inputs.DST_REPO }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  test-reset:
+    name: Mutate dst_repo, reset the dst_repo, check for mutation
+    runs-on: ubuntu-latest
+    needs: dst-reset
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.DST_REPO }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: smoke-repo
+      - name: Make a change and commit it
+        working-directory: smoke-repo
+        run: |
+          echo "This should be wiped" > SMOKE_MUTATION.txt
+          git config user.name "Smoke Tester"
+          git config user.email "smoke@example.com"
+          git add SMOKE_MUTATION.txt
+          git commit -m "smoke: mutate repo with dummy file"
+          git push origin HEAD
+      - name: Confirm mutation exists
+        working-directory: smoke-repo
+        run: |
+          test -f SMOKE_MUTATION.txt
+          grep "This should be wiped" SMOKE_MUTATION.txt
+  call-reset:
+    name: Call Reset Workflow
+    uses: ./.github/workflows/core-reset-smoke-repo.yaml
+    needs: test-reset
+    with:
+      src_repo: ${{ inputs.SRC_REPO }}
+      dst_repo: ${{ inputs.DST_REPO }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  verify-reset:
+    name: Confirm repo was reset
+    needs: call-reset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout smoke repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.SRC_REPO }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: smoke-repo
+      - name: Assert that mutation is gone
+        working-directory: smoke-repo
+        run: |-
+          if [[ -f SMOKE_MUTATION.txt ]]; then
+            echo "❌ Reset failed: SMOKE_MUTATION.txt still exists"
+            exit 1
+          else
+            echo "✅ Reset successful: SMOKE_MUTATION.txt is gone"
+          fi
+  check-rulesets:
+    name: Check if branch rulesets are enabled
+    needs: verify-reset
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruleset:
+          - path: ./smoke-repo/.github/rulesets/branch-default.json
+          - path: ./smoke-repo/.github/rulesets/branch-release.json
+          - path: ./smoke-repo/.github/rulesets/branch-development.json
+          - path: ./smoke-repo/.github/rulesets/branch-feature.json
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.dst_repo }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: smoke-repo
+      - name: "Load JSON: ruleset = ${{ matrix.ruleset.path }}"
+        id: load-json
+        uses: ./smoke-repo/.github/actions/load-json
+        with:
+          path: ${{ matrix.ruleset.path }}
+      - name: "Query GitHub REST API for ruleset ${{ matrix.ruleset.path }}"
+        id: query
+        uses: ./smoke-repo/.github/actions/github-rest-api
+        with:
+          endpoint: /repos/robert-portelli/smoke-utils-repl/rulesets/${{ steps.load-json.outputs.ruleset_name
+            }}
+          method: GET
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extract: '.enforcement'
+          expected: 'active'
+          retries: 3
+          delay: 5

--- a/.github/workflows/smoke-github-rest-api-action.yaml
+++ b/.github/workflows/smoke-github-rest-api-action.yaml
@@ -1,27 +1,72 @@
 ---
-name: 🔥 Smoke Test GitHub REST API Action
+name: Smoke Test GitHub REST API Action
 on:
   workflow_dispatch:
 jobs:
-  smoke-test:
-    name: 🔬 Test github-rest-api action
+  matrix-smoke-test:
+    name: Matrix Test github-rest-api
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test_case: [get-metadata, post-polling, get-bad-token]
     steps:
       - name: ✅ Check out repository
         uses: actions/checkout@v4
-      - name: 🔍 Make GET request to fetch repo metadata
-        id: repo
+      - name: 🔍 GET repo metadata
+        if: matrix.test_case == 'get-metadata'
+        id: get
         uses: ./.github/actions/github-rest-api
         with:
           method: GET
           endpoint: /repos/${{ github.repository }}
           token: ${{ secrets.GITHUB_TOKEN }}
           extract: '.full_name'
-      - name: 🧪 Verify extracted value
+      - name: 🧪 Verify extracted repo full_name
+        if: matrix.test_case == 'get-metadata'
         run: |-
-          echo "Extracted: '${{ steps.repo.outputs.result }}'"
-          if [[ "${{ steps.repo.outputs.result }}" != "${GITHUB_REPOSITORY}" ]]; then
+          echo "Extracted: '${{ steps.get.outputs.result }}'"
+          [[ "${{ steps.get.outputs.result }}" == "${GITHUB_REPOSITORY}" ]] || {
             echo "❌ Unexpected repository full_name"
             exit 1
+          }
+          echo "✅ Passed: GET repo metadata"
+      - name: ⏱️ POST + polling test (check repo visibility)
+        if: matrix.test_case == 'post-polling'
+        id: poll
+        uses: ./.github/actions/github-rest-api
+        with:
+          method: GET
+          endpoint: /repos/${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extract: '.visibility'
+          expected: 'public'
+          retries: 5
+          delay: 2
+      - name: 🧪 Check visibility polling result
+        if: matrix.test_case == 'post-polling'
+        run: |-
+          echo "Extracted: '${{ steps.poll.outputs.result }}'"
+          [[ "${{ steps.poll.outputs.result }}" == "public" ]] || {
+            echo "❌ Visibility not as expected"
+            exit 1
+          }
+          echo "✅ Passed: Polling with expected value"
+      - name: ❌ Simulate failure with bad token
+        if: matrix.test_case == 'get-bad-token'
+        id: fail
+        continue-on-error: true
+        uses: ./.github/actions/github-rest-api
+        with:
+          method: GET
+          endpoint: /repos/${{ github.repository }}
+          token: dummy_invalid_token
+          extract: '.full_name'
+      - name: 🧪 Ensure failure occurred
+        if: matrix.test_case == 'get-bad-token'
+        run: |-
+          if [[ "${{ steps.fail.outcome }}" != "failure" ]]; then
+            echo "❌ Expected failure but got success"
+            exit 1
           fi
-          echo "✅ Smoke test passed"
+          echo "✅ Passed: Bad token triggers error"

--- a/.github/workflows/smoke-upsert-ruleset.yaml
+++ b/.github/workflows/smoke-upsert-ruleset.yaml
@@ -1,0 +1,125 @@
+# .github/workflows/smoke-upsert-ruleset.yaml
+---
+name: Smoke Test Upsert Ruleset Composite Action
+on:
+  workflow_dispatch:
+    inputs:
+      src_repo:
+        required: true
+        type: string
+        default: robert-portelli/utils-repl
+      dst_repo:
+        required: true
+        type: string
+        default: robert-portelli/smoke-utils-repl
+jobs:
+  load-json:
+    name: Load Toy Ruleset JSON
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.load.outputs.json }}
+      ruleset_name: ${{ steps.load.outputs.ruleset_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Load toy ruleset
+        id: load
+        uses: ./.github/actions/load-json
+        with:
+          path: .github/rulesets/toy-ruleset.json
+  upsert:
+    name: Upsert Toy Ruleset via Composite
+    needs: load-json
+    runs-on: ubuntu-latest
+    outputs:
+      ruleset_id: ${{ steps.upsert.outputs.ruleset_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upsert ruleset using composite
+        id: upsert
+        uses: ./.github/actions/upsert-ruleset
+        with:
+          json: ${{ needs.load-json.outputs.json }}
+          ruleset_name: ${{ needs.load-json.outputs.ruleset_name }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          ci_admin: ${{ secrets.CI_ADMIN }}
+  core-validate-ruleset:
+    needs: [load-json, upsert]
+    uses: ./.github/workflows/core-validate-ruleset.yaml
+    with:
+      expected_json: ${{ toJSON(fromJSON(needs.load-json.outputs.json)) }}
+      ruleset_id: ${{ needs.upsert.outputs.ruleset_id }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  dst-reset:
+    name: Start the smoke repo from a known state
+    needs: core-validate-ruleset
+    uses: ./.github/workflows/core-reset-smoke-repo.yaml
+    with:
+      src_repo: ${{ inputs.SRC_REPO }}
+      dst_repo: ${{ inputs.DST_REPO }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  dst-load-json:
+    name: Load Toy Ruleset JSON
+    needs: dst-reset
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.load-json.outputs.json }}
+      ruleset_name: ${{ steps.load-json.outputs.ruleset_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.dst_repo }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: smoke-repo
+      - name: "DST Load JSON"
+        id: load-json
+        uses: ./smoke-repo/.github/actions/load-json
+        with:
+          path: .github/rulesets/toy-ruleset.json
+  dst-upsert:
+    name: DST Upsert Toy Ruleset via Composite
+    needs: dst-load-json
+    runs-on: ubuntu-latest
+    outputs:
+      ruleset_id: ${{ steps.upsert.outputs.ruleset_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.dst_repo }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: smoke-repo
+      - name: Upsert ruleset using composite
+        id: upsert
+        uses: ./smoke-repo/.github/actions/upsert-ruleset
+        with:
+          json: ${{ needs.dst-load-json.outputs.json }}
+          ruleset_name: ${{ needs.dst-load-json.outputs.ruleset_name }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          ci_admin: ${{ secrets.CI_ADMIN }}
+          repo: ${{ inputs.dst_repo }}
+  dst-core-validate-ruleset:
+    needs: [dst-load-json, dst-upsert]
+    uses: robert-portelli/smoke-utils-repl/.github/workflows/core-validate-ruleset.yaml@main
+    with:
+      expected_json: ${{ toJSON(fromJSON(needs.dst-load-json.outputs.json)) }}
+      ruleset_id: ${{ needs.dst-upsert.outputs.ruleset_id }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  cleanup:
+    name: Cleanup Toy Ruleset
+    needs: [upsert, core-validate-ruleset]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete toy ruleset
+        uses: ./.github/actions/github-rest-api
+        with:
+          method: DELETE
+          endpoint: /repos/${{ github.repository }}/rulesets/${{ needs.upsert.outputs.ruleset_id
+            }}
+          token: ${{ secrets.CI_ADMIN }}


### PR DESCRIPTION
### Summary

This PR introduces a new GitHub composite action for upserting branch protection rulesets, along with supporting smoke test workflows and enhancements to the core `github-rest-api` action. It enables dynamic, reusable, and validated enforcement of branch protection rules across repositories.

### Changes

#### ✅ New Composite Action
- **`.github/actions/upsert-ruleset/action.yml`**
  - Accepts a ruleset JSON body and name.
  - Detects if the ruleset already exists (via `GET`) and decides between `POST` or `PUT`.
  - Accepts optional `repo` input to support upsertion in remote repositories.

#### 🔥 Smoke Testing for Upsert Logic
- **`.github/workflows/smoke-upsert-ruleset.yaml`**
  - Loads a toy ruleset JSON.
  - Upserts the ruleset in the source repo using the composite action.
  - Resets a destination smoke repo (`dst_repo`) via reusable reset workflow.
  - Repeats upsert and validation in the smoke repo context.
  - Asserts correctness of ruleset application in both local and remote workflows.

#### 🔁 Reset Workflow for Smoke Repos
- **`.github/workflows/core-reset-smoke-repo.yaml`**
  - Mirrors the source repo into the destination.
  - Applies `branch-default`, `branch-release`, `branch-development`, and `branch-feature` rulesets.
  - Validates each ruleset using `core-validate-ruleset` and REST API polling.

- **`.github/workflows/smoke-core-reset-smoke-repo.yaml`**
  - Smoke tests the reset workflow.
  - Mutates the smoke repo and verifies that the reset wipes the change.
  - Ensures branch protection rulesets are reapplied and enforced.

#### 🔄 Enhancements to `github-rest-api`
- Added polling support:
  - Inputs: `expected`, `retries`, `delay`
  - Loops until `.extract` matches `.expected` or retries exhausted.
- Smoke test now uses matrix to cover:
  - Success (`get-metadata`)
  - Polling (`post-polling`)
  - Failure (`get-bad-token`)

### Benefits

- Modular and reusable ruleset upsertion for any GitHub repo.
- Validated smoke test pipelines for both source and destination environments.
- Foundation for end-to-end enforcement testing of branch protection workflows.
- Improved CI robustness with polling support for eventual consistency scenarios.


- **feat(github-rest-api): add polling support with retries, delay, and expected value**
- **feat(core-reset-smoke-repo): add workflow to mirror source repo and apply rulesets**
- **feat(upsert-ruleset): add composite action and smoke test workflow**
