### PR TITLE
feature/smoke test workflow enhancements

### DIFF
--- a/.github/actions/cleanup-temp-ruleset/action.yml
+++ b/.github/actions/cleanup-temp-ruleset/action.yml
@@ -1,0 +1,51 @@
+---
+name: "Cleanup Temporary Branch Ruleset"
+description: "Delete a branch ruleset, used for smoke testing, from the repo"
+inputs:
+  ruleset_id:
+    type: number
+    description: "The integer assigned to the ruleset by GitHub."
+    required: true
+  repo:
+    type: string
+    description: "Target repo for ruleset operations. Passing a value will override
+      `github.repository`"
+    required: false
+  gh_token:
+    type: string
+    description: “Restricted PAT for lookup”
+    required: true
+  ci_admin_token:
+    type: string
+    description: “Admin token for destructive operations”
+    required: true
+outputs: {}
+runs:
+  using: "composite"
+  steps:
+    - name: Set repo variable
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.repo }}" ]]; then
+          echo "REPO=${GITHUB_REPOSITORY}" >> "$GITHUB_ENV"
+        else
+          echo "REPO=${{ inputs.repo }}" >> "$GITHUB_ENV"
+        fi
+    - name: "Delete Repo Branch Ruleset: id = ${{ inputs.ruleset_id }}"
+      id: delete
+      uses: ./.github/actions/github-rest-api
+      # outputs:
+      #  status
+      with:
+        method: DELETE
+        endpoint: /repos/${{ env.REPO }}/rulesets/${{ inputs.ruleset_id }}
+        token: ${{ inputs.ci_admin_token }}
+    - name: "Verify Ruleset Deletion"
+      shell: bash
+      run: |-
+        STATUS="${{ steps.delete.outputs.status }}"
+        if [[ "$STATUS" != "200" && "$STATUS" != "204" ]]; then
+          echo "❌ Ruleset ${{ inputs.ruleset_id }} was not deleted (HTTP $STATUS)."
+          exit 1
+        fi
+        echo "✅ Ruleset ${{ inputs.ruleset_id }} deleted (HTTP $STATUS)."

--- a/.github/actions/gate-admin/action.yml
+++ b/.github/actions/gate-admin/action.yml
@@ -1,0 +1,31 @@
+---
+name: "admin-check"
+description: "Is the caller an admin"
+inputs:
+  gh_token:
+    description: "Restricted PAT"
+    required: true
+outputs:
+  permission:
+    description: "The caller’s permission level"
+    value: ${{ steps.get-perm.outputs.result }}
+runs:
+  using: "composite"
+  steps:
+    - name: Get actor permission
+      id: get-perm
+      uses: ./.github/actions/github-rest-api
+      with:
+        method: GET
+        endpoint: /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission
+        extract: '.permission'
+        token: ${{ inputs.gh_token }}
+    - name: Deny if not admin
+      if: ${{ steps.get-perm.outputs.result != 'admin' }}
+      run: |
+        echo "❌ You must be a repo admin to run this."
+        exit 1
+    - name: Permission check passed
+      if: ${{ steps.get-perm.outputs.result == 'admin' }}
+      run: |-
+        echo "✅ Permission check passed."

--- a/.github/actions/load-json/action.yml
+++ b/.github/actions/load-json/action.yml
@@ -5,6 +5,10 @@ inputs:
   path:
     description: "Path to the JSON file"
     required: true
+  smoke:
+    description: "Whether or not to smoke the JSON file"
+    required: false
+    default: ''
   compact:
     description: "Output compacted JSON"
     required: false
@@ -12,10 +16,13 @@ inputs:
 outputs:
   json:
     description: "Stringified JSON content"
-    value: ${{ steps.load.outputs.json }}
+    value: ${{ steps.return.outputs.json }}
   ruleset_name:
     description: "Extracted value of .name from the JSON"
-    value: ${{ steps.load.outputs.ruleset_name }}
+    value: ${{ steps.return.outputs.ruleset_name }}
+  target_ref:
+    description: "Extract value of .conditions.ref_name.include"
+    value: ${{steps.return.outputs.target_ref }}
   compact_json:
     description: "Compacted JSON for submission to APIs"
     value: ${{ steps.compact.outputs.compact_json }}
@@ -30,17 +37,53 @@ runs:
           exit 1
         }
     - id: load
-      if: ${{ inputs.compact == 'false' }}
+      if: ${{ inputs.compact == 'false' && inputs.smoke == '' }}
       shell: bash
       run: |-
-        JSON=$(cat "${{ inputs.path }}")
-        NAME=$(echo "$JSON" | jq -r '.name')
+        _JSON=$(cat "${{ inputs.path }}")
+        _NAME=$(echo "$_JSON" | jq -r '.name')
+        _REF=$(echo "$_JSON" | jq -r '.conditions.ref_name.include[0]')
 
+        {
+          echo 'JSON<<EOF'
+          echo "$_JSON"
+          echo 'EOF'
+          echo "RULESET_NAME=$_NAME"
+          echo "REF=$_REF"
+        } >> "$GITHUB_ENV"
+    - id: smoke
+      if: ${{ inputs.compact == 'false' && inputs.smoke != '' }}
+      shell: bash
+      run: |-
+        _JSON=$(cat "${{ inputs.path }}")
+        default_branch="${GITHUB_REF_NAME:-main}"
+        {
+          _modified_json="$(echo "$_JSON" | jq \
+            --arg default_branch "$default_branch" \
+            '.name |= "smoke-\(.)" |
+             .conditions.ref_name.include |= map(
+               if . == "~DEFAULT" then "refs/heads/smoke-\($default_branch)"
+               elif . == "~ALL" then .
+               elif startswith("refs/heads/") then "refs/heads/smoke-\(.[11:])"
+               else .
+               end
+             )')"
+
+          echo 'JSON<<EOF'
+          echo "$_modified_json"
+          echo 'EOF'
+          echo "RULESET_NAME=$(echo "$_modified_json" | jq -r '.name')"
+          echo "REF=$(echo "$_modified_json" | jq -r '.conditions.ref_name.include[0]')"
+        } >> "$GITHUB_ENV"
+    - id: return
+      if: ${{ env.JSON != '' && env.RULESET_NAME != '' }}
+      run: |-
         {
           echo 'json<<EOF'
           echo "$JSON"
           echo 'EOF'
-          echo "ruleset_name=$NAME"
+          echo "ruleset_name=$RULESET_NAME"
+          echo "target_ref=$REF"
         } >> "$GITHUB_OUTPUT"
     - id: compact
       if: ${{ inputs.compact == 'true' }}

--- a/.github/actions/load-json/action.yml
+++ b/.github/actions/load-json/action.yml
@@ -4,15 +4,18 @@ description: "Load a JSON file and emit it as a string"
 inputs:
   path:
     description: "Path to the JSON file"
+    type: string
     required: true
   smoke:
     description: "Whether or not to smoke the JSON file"
+    type: boolean
     required: false
-    default: ''
+    default: false
   compact:
     description: "Output compacted JSON"
+    type: boolean
     required: false
-    default: 'false'
+    default: false
 outputs:
   json:
     description: "Stringified JSON content"

--- a/.github/actions/mirror-clone-repo/action.yml
+++ b/.github/actions/mirror-clone-repo/action.yml
@@ -1,0 +1,32 @@
+---
+name: "mirror-clone-repo"
+description: "Mirror clone source repository to destination repository"
+inputs:
+  src_repo:
+    description: "Source repository to mirror (e.g. owner/repo)"
+    required: true
+    type: string
+  dst_repo:
+    description: "Destination repository (e.g. owner/smoke-repo)"
+    required: true
+    type: string
+  gh_token:
+    description: "Restricted PAT"
+    required: true
+  ci_admin_token:
+    description: "Admin token"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Mirror clone source repo
+      run: |
+        git clone --mirror https://x-access-token:${{ inputs.gh_token }}@github.com/${{ inputs.src_repo }} /tmp/mirror.git
+    - name: Push mirror to destination
+      working-directory: /tmp/mirror.git
+      run: |-
+        # Remove hidden refs
+        git for-each-ref --format='%(refname)' refs/pull | xargs -n 1 git update-ref -d
+
+        git remote set-url origin https://x-access-token:${{ inputs.ci_admin_token }}@github.com/${{ inputs.dst_repo }}
+        git push --mirror

--- a/.github/actions/upsert-ruleset/action.yml
+++ b/.github/actions/upsert-ruleset/action.yml
@@ -18,7 +18,6 @@ inputs:
   repo:
     description: "Target repo for ruleset operations"
     required: false
-    default: ${{ github.repository }}
 outputs:
   ruleset_id:
     description: "The resulting ruleset ID"
@@ -26,13 +25,21 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set repo variable
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.repo }}" ]]; then
+          echo "REPO=${GITHUB_REPOSITORY}" >> "$GITHUB_ENV"
+        else
+          echo "REPO=${{ inputs.repo }}" >> "$GITHUB_ENV"
+        fi
     - uses: actions/checkout@v4
     - name: Lookup ruleset ID
       id: lookup
       uses: ./.github/actions/github-rest-api
       with:
         method: GET
-        endpoint: /repos/${{ inputs.repo }}/rulesets
+        endpoint: /repos/${{ env.REPO }}/rulesets
         token: ${{ inputs.gh_token }}
         extract: '.[] | select(.name == \"${{ inputs.ruleset_name }}\") | .id'
     - name: Determine method
@@ -41,10 +48,10 @@ runs:
       run: |
         if [[ -n "${{ steps.lookup.outputs.result }}" ]]; then
           echo "METHOD=PUT" >> "$GITHUB_ENV"
-          echo "ENDPOINT=/repos/${{ inputs.repo }}/rulesets/${{ steps.lookup.outputs.result }}" >> "$GITHUB_ENV"
+          echo "ENDPOINT=/repos/${{ env.REPO }}/rulesets/${{ steps.lookup.outputs.result }}" >> "$GITHUB_ENV"
         else
           echo "METHOD=POST" >> "$GITHUB_ENV"
-          echo "ENDPOINT=/repos/${{ inputs.repo }}/rulesets" >> "$GITHUB_ENV"
+          echo "ENDPOINT=/repos/${{ env.REPO }}/rulesets" >> "$GITHUB_ENV"
         fi
     - name: Upsert Ruleset
       id: post

--- a/.github/rulesets/toy-ruleset.json
+++ b/.github/rulesets/toy-ruleset.json
@@ -5,7 +5,7 @@
   "bypass_actors": [],
   "conditions": {
     "ref_name": {
-      "include": ["~ALL"],
+      "include": ["refs/heads/toy-branch"],
       "exclude": []
     }
   },

--- a/.github/workflows/core-upsert-ruleset.yaml
+++ b/.github/workflows/core-upsert-ruleset.yaml
@@ -22,7 +22,7 @@ on:
         value: ${{ jobs.core-upsert-ruleset.outputs.ruleset_id }}
 jobs:
   # does the ruleset already exist in the repo
-  put-or-post:
+  upsert-method:
     name: Determine API method
     uses: ./.github/workflows/fetch-ruleset-id.yaml
     with:
@@ -31,20 +31,20 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
   core-upsert-ruleset:
     name: Upsert Ruleset
-    needs: put-or-post
+    needs: upsert-method
     runs-on: ubuntu-latest
     outputs:
       ruleset_id: ${{ steps.post-ruleset.outputs.result }}
     steps:
       - name: PUT an existing ruleset
         id: method-put
-        if: ${{ needs.put-or-post.outputs.ruleset_id }}
+        if: ${{ needs.upsert-method.outputs.ruleset_id }}
         run: |-
           echo "METHOD=PUT" >> "$GITHUB_ENV"
-          echo "ENDPOINT=/repos/${GITHUB_REPOSITORY}/rulesets/${{ needs.put-or-post.outputs.ruleset_id }}" >> "$GITHUB_ENV"
+          echo "ENDPOINT=/repos/${GITHUB_REPOSITORY}/rulesets/${{ needs.upsert-method.outputs.ruleset_id }}" >> "$GITHUB_ENV"
       - name: POST a new ruleset
         id: method-post
-        if: ${{ ! needs.put-or-post.outputs.ruleset_id }}
+        if: ${{ ! needs.upsert-method.outputs.ruleset_id }}
         run: |-
           echo "METHOD=POST" >> "$GITHUB_ENV"
           echo "ENDPOINT=/repos/${{ github.repository }}/rulesets" >> "$GITHUB_ENV"
@@ -54,7 +54,7 @@ jobs:
           echo "❌ METHOD not set"
           exit 1
       - uses: actions/checkout@v4
-      - name: Upsert Default Branch Ruleset
+      - name: Upsert Branch Ruleset
         id: post-ruleset
         uses: ./.github/actions/github-rest-api
         with:

--- a/.github/workflows/core-upsert-ruleset.yaml
+++ b/.github/workflows/core-upsert-ruleset.yaml
@@ -19,8 +19,9 @@ on:
     outputs:
       ruleset_id:
         description: "The post-upsert ID of the ruleset"
-        value: ${{ jobs.upsert.outputs.ruleset_id }}
+        value: ${{ jobs.core-upsert-ruleset.outputs.ruleset_id }}
 jobs:
+  # does the ruleset already exist in the repo
   put-or-post:
     name: Determine API method
     uses: ./.github/workflows/fetch-ruleset-id.yaml
@@ -28,7 +29,7 @@ jobs:
       ruleset_name: ${{ inputs.ruleset_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  upsert:
+  core-upsert-ruleset:
     name: Upsert Ruleset
     needs: put-or-post
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-core.yaml
+++ b/.github/workflows/smoke-core.yaml
@@ -3,7 +3,7 @@ name: Smoke Test Core Logic
 on:
   workflow_dispatch:
 jobs:
-  load-toy-json:
+  load-json:
     name: Load Toy Ruleset JSON
     runs-on: ubuntu-latest
     outputs:
@@ -18,19 +18,19 @@ jobs:
           path: .github/rulesets/toy-ruleset.json
   core-upsert-ruleset:
     name: Upsert Toy Ruleset
-    needs: load-toy-json
+    needs: load-json
     uses: ./.github/workflows/core-upsert-ruleset.yaml
     with:
-      json: ${{ needs.load-toy-json.outputs.json }}
-      ruleset_name: ${{ needs.load-toy-json.outputs.ruleset_name }}
+      json: ${{ needs.load-json.outputs.json }}
+      ruleset_name: ${{ needs.load-json.outputs.ruleset_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
   core-validate-ruleset:
-    needs: [load-toy-json, core-upsert-ruleset]
+    needs: [load-json, core-upsert-ruleset]
     uses: ./.github/workflows/core-validate-ruleset.yaml
     with:
-      expected_json: ${{ toJSON(fromJSON(needs.load-toy-json.outputs.json)) }}
+      expected_json: ${{ toJSON(fromJSON(needs.load-json.outputs.json)) }}
       ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-dst.yaml
+++ b/.github/workflows/smoke-dst.yaml
@@ -1,0 +1,66 @@
+---
+name: Smoke Test Default Branch Ruleset Workflow
+on:
+  workflow_dispatch:  # calling the smoke test directly
+    inputs:
+      ruleset_path:
+        description: "the path to the ruleset json"
+        required: true
+        type: string
+        default: "./.github/rulesets/branch-default.json"
+      src_repo:
+        description: "Source repository to mirror (e.g. owner/repo)"
+        required: true
+        type: string
+        default: robert-portelli/utils-repl
+      dst_repo:
+        description: "Destination smoke repository (e.g. owner/smoke-repo)"
+        required: true
+        type: string
+        default: robert-portelli/smoke-utils-repl
+jobs:
+  test-destination-repo:
+    name: Mutate a destination repo from the source repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Mirror clone source repo
+        uses: ./.github/actions/mirror-clone-repo
+        with:
+          src_repo: ${{ inputs.src_repo }}
+          dst_repo: ${{ inputs.dst_repo }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          ci_admin_token: ${{ secrets.CI_ADMIN }}
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.dst_repo }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: smoke-repo
+      - name: Load Toy Ruleset JSON
+        id: load-json
+        # outputs:
+        # json
+        # ruleset_name
+        uses: ./smoke-repo/.github/actions/load-json
+        with:
+          path: ./smoke-repo/.github/rulesets/toy-ruleset.json
+      - name: DST Upsert Toy Ruleset via Composite
+        id: upsert-ruleset
+        # outputs:
+        # ruleset_id
+        uses: ./smoke-repo/.github/actions/upsert-ruleset
+        with:
+          json: ${{ steps.load-json.outputs.json }}
+          ruleset_name: ${{ steps.load-json.outputs.ruleset_name }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          ci_admin: ${{ secrets.CI_ADMIN }}
+          repo: ${{ inputs.dst_repo }}
+      - name: validate upserted ruleset
+        id: validate
+        uses: ./smoke-repo/.github/actions/validate-ruleset
+        with:
+          expected_json: ${{ toJSON(fromJSON(steps.load-json.outputs.json)) }}
+          ruleset_id: ${{ steps.upsert-ruleset.outputs.ruleset_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          ci_admin_token: ${{ secrets.CI_ADMIN }}
+          repo: ${{ inputs.dst_repo }}

--- a/.github/workflows/smoke-gate-admin.yaml
+++ b/.github/workflows/smoke-gate-admin.yaml
@@ -1,10 +1,40 @@
 ---
 name: Smoke Test Gate Admin
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
 jobs:
-  smoke-admin-check:
-    name: Smoke Test admin-check workflow
-    uses: ./.github/workflows/gate-admin.yaml
-    secrets:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  smoke-gate-admin:
+    name: Smoke Test Gate Admin Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Truthy Admin Token
+        id: truthy
+        uses: ./.github/actions/gate-admin
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assert truthy admin check succeeded
+        if: ${{ steps.truthy.outcome == 'failure' || steps.truthy.outputs.permission
+          != 'admin' }}
+        run: |
+          echo "Expected the admin‐check action to succeed with a valid token"
+          exit 1
+      - name: Truthy  admin check behaved as expected
+        if: ${{ steps.truthy.outcome == 'success' && steps.truthy.outputs.permission
+          == 'admin' }}
+        run: echo "Invalid token was correctly accepted"
+      - name: Falsy Admin Token
+        id: falsy
+        uses: ./.github/actions/gate-admin
+        with:
+          gh_token: dummy.token
+        continue-on-error: true
+      - name: Assert falsy admin check failed
+        if: ${{ steps.falsy.outcome != 'failure' }}
+        run: |
+          echo "Expected the admin‐check action to fail with an invalid token"
+          exit 1
+      - name: Falsy admin check behaved as expected
+        if: ${{ steps.falsy.outcome == 'failure' && steps.falsy.outputs.permission
+          != 'admin'}}
+        run: echo "Invalid token was correctly rejected"

--- a/.github/workflows/smoke-load-json.yaml
+++ b/.github/workflows/smoke-load-json.yaml
@@ -1,45 +1,32 @@
 ---
-name: Smoke Test Load JSON Action
+name: Smoke Test Load JSON (Matrix)
 on:
   workflow_dispatch:
-  workflow_call:
 jobs:
-  test-load-json:
-    runs-on: ubuntu-latest
-    env:
-      known_ruleset_name: "toy-ruleset"
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Load JSON with compact=false
-        id: load-pretty
-        uses: ./.github/actions/load-json
-        with:
-          path: .github/rulesets/toy-ruleset.json
-      - name: Assert pretty JSON output is valid
-        run: |
-          echo '${{ steps.load-pretty.outputs.json }}' | jq empty
-      - name: Assert ruleset_name is found
-        if: ${{ steps.load-pretty.outputs.ruleset_name != env.known_ruleset_name }}
-        run: |-
-          echo "❌ ruleset_name doesn't match"
-          echo "known_ruleset_name = ${env.known_ruleset_name}"
-          echo "found ruleset_name = ${{ steps.load-pretty.outputs.ruleset_name }}"
-          exit 1
-      - name: Load JSON with compact=true
-        id: load-compact
-        uses: ./.github/actions/load-json
-        with:
-          path: .github/rulesets/toy-ruleset.json
-          compact: true
-      - name: Assert compact JSON output is valid
-        run: |
-          echo '${{ steps.load-compact.outputs.compact_json }}' | jq empty
-      - name: Print all outputs
-        run: |-
-          echo "📦 json (pretty):"
-          echo '${{ steps.load-pretty.outputs.json }}'
-          echo "📛 ruleset_name:"
-          echo '${{ steps.load-pretty.outputs.ruleset_name }}'
-          echo "📦 json (compact):"
-          echo '${{ steps.load-compact.outputs.compact_json }}'
+  run-matrix:
+    strategy:
+      matrix:
+        test_case:
+          - id: pretty
+            compact: false
+            smoke: ''
+            expected_name: toy-ruleset
+            expected_ref: refs/heads/toy-branch
+          - id: smoked
+            compact: false
+            smoke: true
+            expected_name: smoke-toy-ruleset
+            expected_ref: refs/heads/smoke-toy-branch
+          - id: compact
+            compact: true
+            smoke: ''
+    name: "Load JSON: id=${{ matrix.test_case.id }}, smoke=${{ matrix.test_case.smoke
+      }}"
+    uses: ./.github/workflows/test-load-json.yaml
+    with:
+      path: .github/rulesets/toy-ruleset.json
+      compact: ${{ matrix.test_case.compact }}
+      smoke: ${{ matrix.test_case.smoke }}
+      expected_name: ${{ matrix.test_case.expected_name }}
+      expected_ref: ${{ matrix.test_case.expected_ref }}
+    secrets: inherit

--- a/.github/workflows/smoke-release.yaml
+++ b/.github/workflows/smoke-release.yaml
@@ -1,0 +1,246 @@
+---
+# .github/workflows/smoke-release.yaml
+name: Smoke End-to-End Release Workflow
+on:
+  workflow_dispatch: {}
+env:
+  FEATURE_BRANCH: feature/smoke-feat
+jobs:
+  gate-admin:
+    name: Check if caller is admin
+    uses: ./.github/workflows/gate-admin.yaml
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+  load-json:
+    name: Load JSON Rulesets
+    outputs:
+      default_branch_json: ${{ steps.load-default.outputs.json }}
+      default_branch_ruleset_name: ${{ steps.load-default.outputs.ruleset_name }}
+      release_branch_json: ${{ steps.load-release.outputs.json }}
+      release_branch_ruleset_name: ${{ steps.load-release.outputs.ruleset_name }}
+      development_branch_json: ${{ steps.load-development.outputs.json }}
+      development_branch_ruleset_name: ${{ steps.load-development.outputs.ruleset_name
+        }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Load default branch ruleset json
+        id: load-default
+        uses: ./.github/actions/load-json
+        with:
+          path: ./.github/rulesets/branch-default.json
+      - name: Load release branch ruleset json
+        id: load-release
+        uses: ./.github/actions/load-json
+        with:
+          path: ./.github/rulesets/branch-release.json
+      - name: Load development branch ruleset json
+        id: load-development
+        uses: ./.github/actions/load-json
+        with:
+          path: ./.github/rulesets/branch-development.json
+  feature-pr-into-development:
+    needs: [gate-admin, load-json]
+    runs-on: ubuntu-latest
+    outputs:
+      feat_br_sha: ${{ steps.feat_br_sha.outputs.feat_br_sha }}
+      dev_pr: ${{ steps.create-dev-pr.outputs.result }}
+    steps:
+      - name: checkout dev branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: development
+          fetch-depth: 0
+      - name: config git
+        run: |-
+          git config --global user.name ${{ github.actor }}
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      - name: create and record feature branch
+        id: feat_br_sha
+        run: |-
+          git checkout -b ${{ env.FEATURE_BRANCH }}
+          echo "feat_br_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Debug workspace
+        run: |
+          echo "Working dir: $PWD"
+          ls -lah .
+      - name: Create smoke‐test commit
+        run: |
+          git commit --allow-empty -m "feat: smoke-release.yaml artifact smoke-test commit #${{ github.run_number }}"
+      - name: push smoke-test artifact
+        run: git push -u origin ${{ env.FEATURE_BRANCH }}
+      - name: Create PR into development
+        id: create-dev-pr
+        uses: ./.github/actions/github-rest-api
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          method: POST
+          endpoint: /repos/${{ github.repository }}/pulls
+          json_body: |
+            {
+              "title": "Smoke test: merge ${{ env.FEATURE_BRANCH }} into development",
+              "head" : "${{ env.FEATURE_BRANCH }}",
+              "base": "development",
+              "body": "Automated smoke-test PR"
+            }
+          extract: '.number'
+  disable-development-ruleset-status-checks:
+    name: Remove status checks from development branch ruleset
+    needs:
+      - load-json
+      - feature-pr-into-development
+    runs-on: ubuntu-latest
+    outputs:
+      disabled_json: ${{ steps.disabled_json.outputs.disabled_json }}
+    steps:
+      - name: Checkout ruleset
+        uses: actions/checkout@v4
+      - name: Delete required_status_checks rule
+        id: disabled_json
+        run: |
+          echo '${{ toJSON(fromJSON(needs.load-json.outputs.development_branch_json)) }}' \
+            | jq '
+                .rules |= map(
+                  if .type=="required_status_checks" then
+                    empty
+                  elif .type=="pull_request" then
+                    .parameters.require_last_push_approval = false |
+                    .parameters.required_approving_review_count = 0 |
+                    .parameters.require_code_owner_review = false
+                  else
+                    .
+                  end
+                )
+              ' \
+            | jq --sort-keys . > disabled.json
+
+          printf 'disabled_json<<EOF\n%s\nEOF\n' "$(cat disabled.json)" \
+            >> "$GITHUB_OUTPUT"
+  core-upsert-ruleset-development:
+    name: Post disabled ruleset
+    needs: [load-json, disable-development-ruleset-status-checks]
+    uses: ./.github/workflows/core-upsert-ruleset.yaml
+    with:
+      json: ${{ needs.disable-development-ruleset-status-checks.outputs.disabled_json
+        }}
+      ruleset_name: ${{ needs.load-json.outputs.development_branch_ruleset_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  merge-feature-pr-into-development:
+    name: Merge Feature PR into Development
+    needs: [feature-pr-into-development, core-upsert-ruleset-development]
+    runs-on: ubuntu-latest
+    outputs:
+      dev_merge_sha: ${{ steps.merge_pr.outputs.result }}
+    steps:
+      - name: checkout dev branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: development
+          fetch-depth: 0
+      - name: Merge the feature PR
+        id: merge_pr
+        uses: ./.github/actions/github-rest-api
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          method: PUT
+          endpoint: /repos/${{ github.repository }}/pulls/${{ needs.feature-pr-into-development.outputs.dev_pr
+            }}/merge
+          json_body: |
+            {
+              "commit_title": "chore(smoke): merge feature branch into development",
+              "merge_method": "merge"
+            }
+          extract: .sha
+      - run: echo "MERGE SHA in merge-feature-pr-into-development job= ${{ steps.merge_pr.outputs.result
+          }}"
+  validate-feature-pr-merged:
+    name: Confirm Feature PR Was Merged
+    needs: [feature-pr-into-development, merge-feature-pr-into-development]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check merged status
+        id: check
+        uses: ./.github/actions/github-rest-api
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          method: GET
+          endpoint: /repos/${{ github.repository }}/pulls/${{ needs.feature-pr-into-development.outputs.dev_pr
+            }}
+          extract: '.merged'
+      - name: Fail if not merged
+        run: |
+          if [[ "${{ steps.check.outputs.result }}" != "true" ]]; then
+            echo "❌ Feature PR was not merged. Aborting."
+            exit 1
+          fi
+  enable-development-ruleset-status-checks:
+    name: Post production development branch ruleset
+    needs:
+      - load-json
+      - disable-development-ruleset-status-checks
+      - merge-feature-pr-into-development
+      - validate-feature-pr-merged
+    uses: ./.github/workflows/core-upsert-ruleset.yaml
+    with:
+      json: ${{ needs.load-json.outputs.development_branch_json }}
+      ruleset_name: ${{ needs.load-json.outputs.development_branch_ruleset_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+  cleanup:
+    name: Cleanup smoke artifacts
+    needs:
+      - feature-pr-into-development
+      - merge-feature-pr-into-development
+      - validate-feature-pr-merged
+      - enable-development-ruleset-status-checks
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      DEV_MERGE_SHA: ${{ needs.merge-feature-pr-into-development.outputs.dev_merge_sha
+        }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          ref: development
+      - name: debug merge sha
+        run: echo "MERGE SHA in cleanup job= ${{ env.DEV_MERGE_SHA }}"
+      - name: config git
+        run: |-
+          git config --global user.name ${{ github.actor }}
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      - name: Sync with remote development branch
+        run: |
+          git fetch origin development
+          git reset --hard origin/development
+      - name: Close feature into development PR
+        uses: ./.github/actions/github-rest-api
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          method: PATCH
+          endpoint: /repos/${{ github.repository }}/pulls/${{ needs.feature-pr-into-development.outputs.dev_pr
+            }}
+          json_body: |
+            { "state": "closed" }
+        continue-on-error: true
+      - name: Revert feature into development PR commit
+        if: ${{ always()  && env.DEV_MERGE_SHA != '' }}
+        run: |
+          git clean -fd
+          git revert --no-edit -m 1 "$DEV_MERGE_SHA"
+          git push origin development
+      - name: Delete remote feature branch via REST API
+        uses: ./.github/actions/github-rest-api
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          method: DELETE
+          endpoint: /repos/${{ github.repository }}/git/refs/heads/${{ env.FEATURE_BRANCH
+            }}
+        continue-on-error: true

--- a/.github/workflows/smoke-upsert-ruleset-default-branch.yaml
+++ b/.github/workflows/smoke-upsert-ruleset-default-branch.yaml
@@ -8,68 +8,12 @@ on:
         required: true
         type: string
         default: "./.github/rulesets/branch-default.json"
-  workflow_call:  # redirect via token gate context, i.e, calling upsert ruleset locally
-    inputs:
-      json:
-        description: "JSON loaded previously in caller."
-        required: true
-        type: string
-      ruleset_name:
-        required: true
-        type: string
-    secrets:
-      GH_TOKEN:
-        required: true
-      CI_ADMIN:
-        required: true
 jobs:
-  load-json:
-    name: Load Ruleset JSON
-    runs-on: ubuntu-latest
-    outputs:
-      # forward inputs if workflow_call, else load-json
-      json: ${{ inputs.json || steps.load-json.outputs.json }}
-      ruleset_name: ${{  inputs.ruleset_name || steps.load-json.outputs.ruleset_name
-        }}
-    steps:
-      - if: ${{ ! inputs.json }}
-        uses: actions/checkout@v4
-      - name: Load production ruleset
-        if: ${{ ! inputs.json }}
-        id: load-json
-        uses: ./.github/actions/load-json
-        with:
-          path: ${{ inputs.ruleset_path }}
-          smoke: true
-  core-upsert-ruleset:
-    name: Post Smoked Ruleset
-    needs: load-json
-    uses: ./.github/workflows/core-upsert-ruleset.yaml
+  upsert-ruleset:
+    name: Upsert Default Branch Ruleset
+    uses: ./.github/workflows/upsert-ruleset-default-branch.yaml
     with:
-      json: ${{ needs.load-json.outputs.json }}
-      ruleset_name: ${{ needs.load-json.outputs.ruleset_name }}
+      ruleset_path: ${{ inputs.ruleset_path }}
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
-  core-validate-ruleset:
-    needs: [load-json, core-upsert-ruleset]
-    uses: ./.github/workflows/core-validate-ruleset.yaml
-    with:
-      expected_json: ${{ needs.load-json.outputs.json }}
-      ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-      CI_ADMIN: ${{ secrets.CI_ADMIN }}
-  cleanup-smoked-ruleset:
-    needs: [core-upsert-ruleset, core-validate-ruleset]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Remove smoke ruleset
-        uses: ./.github/actions/github-rest-api
-        with:
-          method: DELETE
-          endpoint: /repos/${{ github.repository }}/rulesets/${{ needs.core-upsert-ruleset.outputs.ruleset_id
-            }}
-          token: ${{ secrets.CI_ADMIN }}

--- a/.github/workflows/smoke-upsert-ruleset-default-branch.yaml
+++ b/.github/workflows/smoke-upsert-ruleset-default-branch.yaml
@@ -1,17 +1,20 @@
 ---
 name: Smoke Test Default Branch Ruleset Workflow
 on:
-  workflow_dispatch:
+  workflow_dispatch:  # calling the smoke test directly
     inputs:
       ruleset_path:
         description: "the path to the ruleset json"
         required: true
         type: string
         default: "./.github/rulesets/branch-default.json"
-  workflow_call:
+  workflow_call:  # redirect via token gate context, i.e, calling upsert ruleset locally
     inputs:
       json:
-        description: "Default Branch Ruleset JSON body."
+        description: "JSON loaded previously in caller."
+        required: true
+        type: string
+      ruleset_name:
         required: true
         type: string
     secrets:
@@ -22,55 +25,37 @@ on:
 jobs:
   load-json:
     name: Load Ruleset JSON
-    outputs:
-      json: ${{ inputs.JSON || steps.load-prod.outputs.json }}
     runs-on: ubuntu-latest
+    outputs:
+      # forward inputs if workflow_call, else load-json
+      json: ${{ inputs.json || steps.load-json.outputs.json }}
+      ruleset_name: ${{  inputs.ruleset_name || steps.load-json.outputs.ruleset_name
+        }}
     steps:
       - if: ${{ ! inputs.json }}
         uses: actions/checkout@v4
       - name: Load production ruleset
         if: ${{ ! inputs.json }}
-        id: load-prod
+        id: load-json
         uses: ./.github/actions/load-json
         with:
           path: ${{ inputs.ruleset_path }}
-  prepare-smoked-ruleset:
-    name: Modify the ruleset to prevent collisions
-    needs: load-json
-    runs-on: ubuntu-latest
-    outputs:
-      smoked_json: ${{ steps.inject.outputs.smoked_json }}
-      smoked_ruleset_name: ${{ steps.name.outputs.ruleset_name }}
-    steps:
-      - name: Inject "smoke:" into ruleset name
-        id: inject
-        run: |
-          {
-          modified_json="$(echo '${{ needs.load-json.outputs.json }}' | jq '.name |= "smoke \(. + "")"')"
-          echo "smoked_json<<EOF"
-          echo "$modified_json"
-          echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Extract ruleset name
-        id: name
-        run: |
-          ruleset_name="$(echo '${{ steps.inject.outputs.smoked_json }}' | jq -r '.name')"
-          echo "ruleset_name=$ruleset_name" >> "$GITHUB_OUTPUT"
+          smoke: true
   core-upsert-ruleset:
     name: Post Smoked Ruleset
-    needs: prepare-smoked-ruleset
+    needs: load-json
     uses: ./.github/workflows/core-upsert-ruleset.yaml
     with:
-      json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
-      ruleset_name: ${{ needs.prepare-smoked-ruleset.outputs.smoked_ruleset_name }}
+      json: ${{ needs.load-json.outputs.json }}
+      ruleset_name: ${{ needs.load-json.outputs.ruleset_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
   core-validate-ruleset:
-    needs: [prepare-smoked-ruleset, core-upsert-ruleset]
+    needs: [load-json, core-upsert-ruleset]
     uses: ./.github/workflows/core-validate-ruleset.yaml
     with:
-      expected_json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
+      expected_json: ${{ needs.load-json.outputs.json }}
       ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-upsert-ruleset-development-branch.yaml
+++ b/.github/workflows/smoke-upsert-ruleset-development-branch.yaml
@@ -8,10 +8,13 @@ on:
         required: true
         type: string
         default: "./.github/rulesets/branch-development.json"
-  workflow_call:
+  workflow_call:  # redirect via token gate context, i.e, calling upsert ruleset locally
     inputs:
       json:
         description: "Development Branch Ruleset JSON body."
+        required: true
+        type: string
+      ruleset_name:
         required: true
         type: string
     secrets:
@@ -22,55 +25,37 @@ on:
 jobs:
   load-json:
     name: Load Ruleset JSON
-    outputs:
-      json: ${{ inputs.JSON || steps.load-prod.outputs.json }}
     runs-on: ubuntu-latest
+    outputs:
+      # forward inputs if workflow_call, else load-json
+      json: ${{ inputs.json || steps.load-json.outputs.json }}
+      ruleset_name: ${{  inputs.ruleset_name || steps.load-json.outputs.ruleset_name
+        }}
     steps:
       - if: ${{ ! inputs.json }}
         uses: actions/checkout@v4
       - name: Load production ruleset
         if: ${{ ! inputs.json }}
-        id: load-prod
+        id: load-json
         uses: ./.github/actions/load-json
         with:
           path: ${{ inputs.ruleset_path }}
-  prepare-smoked-ruleset:
-    name: Modify the ruleset to prevent collisions
-    needs: load-json
-    runs-on: ubuntu-latest
-    outputs:
-      smoked_json: ${{ steps.inject.outputs.smoked_json }}
-      smoked_ruleset_name: ${{ steps.name.outputs.ruleset_name }}
-    steps:
-      - name: Inject "smoke:" into ruleset name
-        id: inject
-        run: |
-          {
-          modified_json="$(echo '${{ needs.load-json.outputs.json }}' | jq '.name |= "smoke \(. + "")"')"
-          echo "smoked_json<<EOF"
-          echo "$modified_json"
-          echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Extract ruleset name
-        id: name
-        run: |
-          ruleset_name="$(echo '${{ steps.inject.outputs.smoked_json }}' | jq -r '.name')"
-          echo "ruleset_name=$ruleset_name" >> "$GITHUB_OUTPUT"
+          smoke: true
   core-upsert-ruleset:
     name: Post Smoked Ruleset
-    needs: prepare-smoked-ruleset
+    needs: load-json
     uses: ./.github/workflows/core-upsert-ruleset.yaml
     with:
-      json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
-      ruleset_name: ${{ needs.prepare-smoked-ruleset.outputs.smoked_ruleset_name }}
+      json: ${{ needs.load-json.outputs.json }}
+      ruleset_name: ${{ needs.load-json.outputs.ruleset_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
   core-validate-ruleset:
-    needs: [prepare-smoked-ruleset, core-upsert-ruleset]
+    needs: [load-json, core-upsert-ruleset]
     uses: ./.github/workflows/core-validate-ruleset.yaml
     with:
-      expected_json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
+      expected_json: ${{ needs.load-json.outputs.json }}
       ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-upsert-ruleset-feature-branch.yaml
+++ b/.github/workflows/smoke-upsert-ruleset-feature-branch.yaml
@@ -14,6 +14,9 @@ on:
         description: "Feature Branch Ruleset JSON body."
         required: true
         type: string
+      ruleset_name:
+        required: true
+        type: string
     secrets:
       GH_TOKEN:
         required: true
@@ -22,55 +25,37 @@ on:
 jobs:
   load-json:
     name: Load Ruleset JSON
-    outputs:
-      json: ${{ inputs.JSON || steps.load-prod.outputs.json }}
     runs-on: ubuntu-latest
+    outputs:
+      # forward inputs if workflow_call, else load-json
+      json: ${{ inputs.json || steps.load-json.outputs.json }}
+      ruleset_name: ${{  inputs.ruleset_name || steps.load-json.outputs.ruleset_name
+        }}
     steps:
       - if: ${{ ! inputs.json }}
         uses: actions/checkout@v4
       - name: Load production ruleset
         if: ${{ ! inputs.json }}
-        id: load-prod
+        id: load-json
         uses: ./.github/actions/load-json
         with:
           path: ${{ inputs.ruleset_path }}
-  prepare-smoked-ruleset:
-    name: Modify the ruleset to prevent collisions
-    needs: load-json
-    runs-on: ubuntu-latest
-    outputs:
-      smoked_json: ${{ steps.inject.outputs.smoked_json }}
-      smoked_ruleset_name: ${{ steps.name.outputs.ruleset_name }}
-    steps:
-      - name: Inject "smoke:" into ruleset name
-        id: inject
-        run: |
-          {
-          modified_json="$(echo '${{ needs.load-json.outputs.json }}' | jq '.name |= "smoke \(. + "")"')"
-          echo "smoked_json<<EOF"
-          echo "$modified_json"
-          echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Extract ruleset name
-        id: name
-        run: |
-          ruleset_name="$(echo '${{ steps.inject.outputs.smoked_json }}' | jq -r '.name')"
-          echo "ruleset_name=$ruleset_name" >> "$GITHUB_OUTPUT"
+          smoke: true
   core-upsert-ruleset:
     name: Post Smoked Ruleset
-    needs: prepare-smoked-ruleset
+    needs: load-json
     uses: ./.github/workflows/core-upsert-ruleset.yaml
     with:
-      json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
-      ruleset_name: ${{ needs.prepare-smoked-ruleset.outputs.smoked_ruleset_name }}
+      json: ${{ needs.load-json.outputs.json }}
+      ruleset_name: ${{ needs.load-json.outputs.ruleset_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
   core-validate-ruleset:
-    needs: [prepare-smoked-ruleset, core-upsert-ruleset]
+    needs: [load-json, core-upsert-ruleset]
     uses: ./.github/workflows/core-validate-ruleset.yaml
     with:
-      expected_json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
+      expected_json: ${{ needs.load-json.outputs.json }}
       ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-upsert-ruleset-release-branch.yaml
+++ b/.github/workflows/smoke-upsert-ruleset-release-branch.yaml
@@ -14,6 +14,9 @@ on:
         description: "Release Branch Ruleset JSON body."
         required: true
         type: string
+      ruleset_name:
+        required: true
+        type: string
     secrets:
       GH_TOKEN:
         required: true
@@ -22,55 +25,37 @@ on:
 jobs:
   load-json:
     name: Load Ruleset JSON
-    outputs:
-      json: ${{ inputs.JSON || steps.load-prod.outputs.json }}
     runs-on: ubuntu-latest
+    outputs:
+      # forward inputs if workflow_call, else load-json
+      json: ${{ inputs.json || steps.load-json.outputs.json }}
+      ruleset_name: ${{  inputs.ruleset_name || steps.load-json.outputs.ruleset_name
+        }}
     steps:
       - if: ${{ ! inputs.json }}
         uses: actions/checkout@v4
       - name: Load production ruleset
         if: ${{ ! inputs.json }}
-        id: load-prod
+        id: load-json
         uses: ./.github/actions/load-json
         with:
           path: ${{ inputs.ruleset_path }}
-  prepare-smoked-ruleset:
-    name: Modify the ruleset to prevent collisions
-    needs: load-json
-    runs-on: ubuntu-latest
-    outputs:
-      smoked_json: ${{ steps.inject.outputs.smoked_json }}
-      smoked_ruleset_name: ${{ steps.name.outputs.ruleset_name }}
-    steps:
-      - name: Inject "smoke:" into ruleset name
-        id: inject
-        run: |
-          {
-          modified_json="$(echo '${{ needs.load-json.outputs.json }}' | jq '.name |= "smoke \(. + "")"')"
-          echo "smoked_json<<EOF"
-          echo "$modified_json"
-          echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Extract ruleset name
-        id: name
-        run: |
-          ruleset_name="$(echo '${{ steps.inject.outputs.smoked_json }}' | jq -r '.name')"
-          echo "ruleset_name=$ruleset_name" >> "$GITHUB_OUTPUT"
+          smoke: true
   core-upsert-ruleset:
     name: Post Smoked Ruleset
-    needs: prepare-smoked-ruleset
+    needs: load-json
     uses: ./.github/workflows/core-upsert-ruleset.yaml
     with:
-      json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
-      ruleset_name: ${{ needs.prepare-smoked-ruleset.outputs.smoked_ruleset_name }}
+      json: ${{ needs.load-json.outputs.json }}
+      ruleset_name: ${{ needs.load-json.outputs.ruleset_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       CI_ADMIN: ${{ secrets.CI_ADMIN }}
   core-validate-ruleset:
-    needs: [prepare-smoked-ruleset, core-upsert-ruleset]
+    needs: [load-json, core-upsert-ruleset]
     uses: ./.github/workflows/core-validate-ruleset.yaml
     with:
-      expected_json: ${{ needs.prepare-smoked-ruleset.outputs.smoked_json }}
+      expected_json: ${{ needs.load-json.outputs.json }}
       ruleset_id: ${{ needs.core-upsert-ruleset.outputs.ruleset_id }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-load-json.yaml
+++ b/.github/workflows/test-load-json.yaml
@@ -1,0 +1,75 @@
+---
+name: Test Suite for Load JSON Action
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: "Path to the JSON file"
+        required: true
+        type: string
+      compact:
+        description: "Set true to compact the JSON"
+        required: false
+        default: false
+        type: boolean
+      smoke:
+        description: "Set to true to simulate smoking the JSON"
+        required: false
+        default: ''
+        type: string
+      expected_name:
+        description: "Expected value of .name in the JSON"
+        required: false
+        type: string
+      expected_ref:
+        description: "Expected value of .conditions.ref_name.include[0]"
+        required: false
+        type: string
+    secrets: {}
+jobs:
+  test-load-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Load JSON
+        id: load
+        uses: ./.github/actions/load-json
+        with:
+          path: ${{ inputs.path }}
+          compact: ${{ inputs.compact }}
+          smoke: ${{ inputs.smoke }}
+      - name: Assert JSON is valid
+        if: ${{ !inputs.compact }}
+        run: |
+          echo '${{ steps.load.outputs.json }}' | jq empty
+      - name: Assert compact JSON is valid
+        if: ${{ inputs.compact }}
+        run: |
+          echo '${{ steps.load.outputs.compact_json }}' | jq empty
+      - name: Assert ruleset_name matches expected
+        if: ${{ inputs.expected_name != '' && steps.load.outputs.ruleset_name != inputs.expected_name
+          }}
+        run: |
+          echo "❌ ruleset_name mismatch"
+          echo "Expected: ${{ inputs.expected_name }}"
+          echo "Found:    ${{ steps.load.outputs.ruleset_name }}"
+          exit 1
+      - name: Assert target_ref matches expected
+        if: ${{ inputs.expected_ref != '' && steps.load.outputs.target_ref != inputs.expected_ref
+          }}
+        run: |
+          echo "❌ target_ref mismatch"
+          echo "Expected: ${{ inputs.expected_ref }}"
+          echo "Found:    ${{ steps.load.outputs.target_ref }}"
+          exit 1
+      - name: Print all outputs
+        run: |-
+          echo "📛 ruleset_name:"
+          echo '${{ steps.load.outputs.ruleset_name }}'
+          echo "🔀 target_ref:"
+          echo '${{ steps.load.outputs.target_ref }}'
+          echo "📦 json (pretty):"
+          echo '${{ steps.load.outputs.json }}'
+          echo "📦 json (compact):"
+          echo '${{ steps.load.outputs.compact_json }}'

--- a/.github/workflows/upsert-ruleset-default-branch.yaml
+++ b/.github/workflows/upsert-ruleset-default-branch.yaml
@@ -8,58 +8,78 @@ on:
         required: true
         type: string
         default: "./.github/rulesets/branch-default.json"
-jobs:
-  gate-admin:
-    name: Check if caller is admin
-    uses: ./.github/workflows/gate-admin.yaml
+  workflow_call:
+    inputs:
+      ruleset_path:
+        description: "the path to the ruleset json"
+        required: true
+        type: string
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-  gate-token:
-    name: Check the caller token
-    needs: gate-admin
+      GH_TOKEN:
+        required: true
+      CI_ADMIN:
+        required: true
+jobs:
+  upsert-ruleset:
+    name: "Upsert Ruleset: ${{ inputs.ruleset_path }}"
     runs-on: ubuntu-latest
+    # remove these outputs after fully ported to actions
     outputs:
-      context: ${{ steps.detect.outputs.context }}
+      context: ${{ steps.gate-token.outputs.context }}
+      json: ${{ steps.load-json.outputs.json }}
+      ruleset_name: ${{ steps.load-json.outputs.ruleset_name }}
+      ruleset_id: ${{ steps.upsert-ruleset.outputs.ruleset_id }}
     steps:
       - uses: actions/checkout@v4
+      - name: Admin Gate
+        uses: ./.github/actions/gate-admin
+        with:
+          gh_token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Detect Token Context
-        id: detect
+        id: gate-token
         uses: ./.github/actions/gate-token
+        # outputs:
+        #  context
         with:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           CI_ADMIN: ${{ secrets.CI_ADMIN }}
-  load-ruleset:
-    name: Load Ruleset JSON and Ruleset Name
-    needs: gate-token
-    outputs:
-      json: ${{ steps.load-prod.outputs.json }}
-      ruleset_name: ${{ steps.load-prod.outputs.ruleset_name }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Load production ruleset
-        id: load-prod
+      - name: "Load Ruleset JSON: ${{ inputs.ruleset_path }}"
+        id: load-json
         uses: ./.github/actions/load-json
+        # outputs:
+        #  json
+        #  ruleset_name
         with:
           path: ${{ inputs.ruleset_path }}
-  local-token:
-    name: smoke the production ruleset and callback with it
-    needs: [gate-token, load-ruleset]
-    if: ${{ needs.gate-token.outputs.context == 'act' }}
-    uses: ./.github/workflows/smoke-upsert-ruleset-default-branch.yaml
-    with:
-      json: ${{ needs.load-ruleset.outputs.json }}
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-      CI_ADMIN: ${{ secrets.CI_ADMIN }}
-  core-upsert-ruleset:
-    name: Upsert Ruleset
-    needs: [gate-token, load-ruleset]
-    if: ${{ needs.gate-token.outputs.context == 'github' }}
-    uses: ./.github/workflows/core-upsert-ruleset.yaml
-    with:
-      json: ${{ needs.load-ruleset.outputs.json }}
-      ruleset_name: ${{ needs.load-ruleset.outputs.ruleset_name }}
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-      CI_ADMIN: ${{ secrets.CI_ADMIN }}
+          # smoke the ruleset json if caller is local act
+          smoke: ${{ steps.gate-token.outputs.context == 'act' }}
+      - name: "Upsert Ruleset: ${{ steps.load-json.outputs.ruleset_name }}"
+        id: upsert-ruleset
+        uses: ./.github/actions/upsert-ruleset
+        # outputs:
+        #  ruleset_id
+        with:
+          json: ${{ steps.load-json.outputs.json }}
+          ruleset_name: ${{ steps.load-json.outputs.ruleset_name }}
+          gh_token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          ci_admin: ${{ secrets.CI_ADMIN }}
+      - name: "Validate Ruleset: name = ${{ steps.load-json.outputs.ruleset_name }},
+          id = ${{ steps.upsert-ruleset.outputs.ruleset_id }}"
+        uses: ./.github/actions/validate-ruleset
+        # outputs:
+        #  No outputs
+        with:
+          expected_json: ${{ toJSON(fromJSON(steps.load-json.outputs.json)) }}
+          ruleset_id: ${{ steps.upsert-ruleset.outputs.ruleset_id }}
+          gh_token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          ci_admin_token: ${{ secrets.CI_ADMIN }}
+      - name: "Delete Temporary Ruleset: ${{ steps.load-json.outputs.ruleset_name
+          }} (id: ${{ steps.upsert-ruleset.outputs.ruleset_id }})"
+        if: ${{ steps.gate-token.outputs.context == 'act' }}
+        uses: ./.github/actions/cleanup-temp-ruleset
+        # outputs:
+        #  No outputs
+        with:
+          ruleset_id: ${{ steps.upsert-ruleset.outputs.ruleset_id }}
+          gh_token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          ci_admin_token: ${{ secrets.CI_ADMIN }}

--- a/.make/act.mk
+++ b/.make/act.mk
@@ -15,7 +15,6 @@ endif
 ACT_BASE := gh act workflow_dispatch \
   --secret-file .secrets \
   --container-architecture linux/amd64 \
-  --reuse \
   --rm \
   --actor $(ACTOR)
 

--- a/.make/dev.mk
+++ b/.make/dev.mk
@@ -1,6 +1,6 @@
 # .make/dev.mk — Development utilities
 
-.PHONY: pc-all pc-one super-linter repl
+.PHONY: pc-all pc-one super-linter repl find-str replace-str
 
 repl: ## Launch the REPL inside the dev container
 	@echo "🧪 Entering REPL..."
@@ -14,3 +14,47 @@ pc-one: ## Run pre-commit on selected files via ARGS
 
 super-linter: ## Run the Super Linter workflow locally using act
 	gh act -W .github/workflows/super-linter.yaml -P ubuntu-latest=$(REGISTRY_USERNAME)/$(IMAGE_NAME)
+
+find-str: ## Find references to a given string in the project directory.
+# Usage:
+#     make find-str SEARCH=<string> [START=<directory>]
+# Arguments:
+#     SEARCH  - The string to search for in file names and file contents.
+#     START   - (Optional) The directory to start searching from. Defaults to the current directory.
+# Behavior:
+#     - Searches for files with names matching *SEARCH*.
+#     - Searches for occurrences of SEARCH within files, excluding .git, venv, and .cache directories.
+#     - Prints matching file paths and line numbers.
+	@find $${START:-.} -type f \
+		! -path "*/.git/*" \
+		! -path "*/venv/*" \
+		! -path "*/.cache/*" \
+		! -name "*~" \
+		! -name "*.bak" \
+		-name "*$(SEARCH)*"
+	@grep -Rni --binary-files=without-match \
+		--exclude-dir={.git,venv,.cache} \
+		--exclude='*~' \
+		--exclude='*.bak' \
+		"$(SEARCH)" $${START:-.} | cut -d: -f1,2
+
+replace-str:## Replace references to a given string in file names and file contents.
+# Usage:
+#     make replace-str SEARCH=<string> REPLACE=<string> [START=<directory>]
+# Arguments:
+#     SEARCH  - The string to search for and replace.
+#     REPLACE - The string to replace SEARCH with.
+#     START   - (Optional) The directory to start replacing from. Defaults to the current directory.
+# Behavior:
+#     - Replaces occurrences of SEARCH with REPLACE in file contents.
+#     - Renames files containing SEARCH in their names to use REPLACE instead.
+#     - Excludes .git, venv, and .cache directories.
+	@grep -Rl --binary-files=without-match --exclude-dir={.git,venv,.cache} --exclude='*~' --exclude='*.bak' "$(SEARCH)" $${START:-.} | xargs -d '\n' sed -i "s/$(SEARCH)/$(REPLACE)/g"
+	@find $${START:-.} -type f \
+		! -path "*/.git/*" \
+		! -path "*/venv/*" \
+		! -path "*/.cache/*" \
+		! -name "*~" \
+		! -name "*.bak" \
+		-name "*$(SEARCH)*" \
+		-exec bash -c 'mv "$$0" "$${0//$(SEARCH)/$(REPLACE)}"' {} \;


### PR DESCRIPTION
### Summary

This PR enhances the smoke testing and CI infrastructure for ruleset management by:

- Unifying smoke and production logic under a shared upsert entrypoint
- Introducing reusable composite actions for admin permission gating and cleanup
- Adding a mirror-based smoke test to validate cross-repo ruleset upsertion
- Improving developer tooling with string search/replace Make targets

### Changes

#### 🧩 Composite Actions
- **`gate-admin`**: Validates if the caller has admin access to the repository
- **`cleanup-temp-ruleset`**: Deletes a temporary ruleset given its ID
- **`mirror-clone-repo`**: Mirrors a source repository to a destination repository, used in cross-repo smoke testing

#### 🔥 Smoke Tests
- **`smoke-gate-admin.yaml`**: Validates `gate-admin` under valid and invalid tokens
- **`smoke-upsert-ruleset-default-branch.yaml`**: Now defers to `upsert-ruleset-default-branch.yaml` for behavior
- **`smoke-dst.yaml`**: New smoke test that:
  - Mirrors the current repo to a sandbox destination
  - Loads a toy ruleset and upserts it via composite actions
  - Validates correctness and cleans up

#### 🔁 Refactors
- **`upsert-ruleset-default-branch.yaml`**:
  - Serves as both a `workflow_dispatch` and `workflow_call` entrypoint
  - Uses inline composite actions for upsert/validate/delete
  - Detects environment context (GitHub vs `act`) and behaves accordingly
- **`smoke-upsert-ruleset-default-branch.yaml`**:
  - Now simply calls the unified entrypoint and passes inputs

#### 🛠 Developer Tooling
- `.make/dev.mk`:
  - Added `find-str` and `replace-str` Make targets for auditing and mass replacement of strings

### Benefits

- 🔄 **Reduces redundancy**: Consolidates workflow logic across test and prod paths
- 🔒 **Enforces access control**: Admin and token checks now reusable and testable
- 🧪 **Supports isolated testing**: Can test ruleset logic against forks or dedicated sandboxes
- 🔧 **Improves DX**: Developer utilities streamline string audits and refactors

### Follow-Up

- Validate GitHub App compatibility for cross-repo ruleset management
- Integrate `smoke-dst.yaml` into CI matrix for isolated validation in real-time

- **chore(act): remove --reuse flag from ACT_BASE**
- **feat(ci): add initial smoke end-to-end release workflow**
- **feat(load-json): support smoking and ref rewriting; refactor test suite**
- **refactor(core-upsert): rename job to core-upsert-ruleset and fix output reference**
- **refactor(smoke): inline smoke mutation via load-json in upsert smoke tests**
- **refactor(load-json): declare typed boolean inputs for smoke and compact**
- **refactor(core-upsert-ruleset): rename method job and clarify routing logic**
- **fix(upsert-ruleset): support fallback to github.repository if repo input is unset**
- **feat(gate-admin): introduce gate-admin composite action with full smoke test coverage**
- **feat(cleanup-temp-ruleset): add composite action to delete temporary branch rulesets**
- **refactor(upsert-ruleset): unify smoke and prod workflows via shared entrypoint**
- **feat(dev.mk): add string search and replace utilities for developer workflows**
- **feat(smoke): add composite action and workflow to mirror repo and upsert ruleset in destination**
